### PR TITLE
ci(release): publish to npm on github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit tests
+        run: npm test -- --run
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- add release workflow triggered by published GitHub releases
- run install/build/tests before publish
- publish to npm with provenance (OIDC trusted publishing)

## Notes
- first package publish is still manual to create package ownership on npm
- after that, enable npm Trusted Publishing for this repo/workflow