### PR TITLE
fix(npm): use publish-valid bin paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "node": ">=20"
   },
   "bin": {
-    "e2a-mcp": "./dist/loader.js",
-    "e2a": "./dist/cli.js"
+    "e2a-mcp": "dist/loader.js",
+    "e2a": "dist/cli.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- update package.json bin entries to publish-valid paths without leading .
- ensures npm retains e2a and e2a-mcp executables on publish
## Validation
- npm publish --dry-run (no bin removal warnings)