### PR TITLE
ci(release): enforce trusted publishing auth path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -31,5 +30,10 @@ jobs:
       - name: Unit tests
         run: npm test -- --run
 
+      - name: Prepare trusted publishing auth
+        run: npm config delete //registry.npmjs.org/:_authToken || true
+
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ''
+        run: npm publish --access public --provenance --registry=https://registry.npmjs.org


### PR DESCRIPTION
## Summary
- stop configuring registry token auth in release workflow
- clear any npm auth token config before publish
- publish using provenance with explicit npm registry

## Why
Previous release run built/tests passed but npm publish failed with 404 on PUT, indicating auth path mismatch. This forces trusted publishing (OIDC) instead of legacy token auth.

## Validation
- workflow syntax change only; release job will validate on next GitHub Release