### PR TITLE
chore(release): 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ether-to-astro",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ether-to-astro",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ether-to-astro",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Local-first astrology toolkit with a CLI (e2a) and MCP server (e2a-mcp) for charts, transits, rendering, and agent workflows.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package version to 1.0.2

## Why
- v1.0.1 npm publish failed before trusted-publishing workflow fix landed
- this release validates the fixed release workflow

## Validation
- version bump only
