### PR TITLE
ci(release): restore oidc publish and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: build
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -31,14 +30,5 @@ jobs:
       - name: Unit tests
         run: npm test -- --run
 
-      - name: Verify npm auth secret
-        run: |
-          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
-            echo "NPM_TOKEN secret is required for release publishing."
-            exit 1
-          fi
-
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance --registry=https://registry.npmjs.org


### PR DESCRIPTION
## Summary
- keep Node 24 in release workflow
- remove token-based npm publish requirement (OIDC trusted publishing only)
- add Dependabot config for npm and GitHub Actions updates
- schedule Dependabot weekly on Monday (America/Los_Angeles)

## Why
- release publish must use trusted publisher OIDC flow
- add dependency update automation requested

## Validation
- workflow/config change only
