### PR TITLE
fix(package): set repository url for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "swiss-ephemeris",
     "transits"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/unsalted/ether-to-astro"
+  },
   "author": "",
   "license": "AGPL-3.0-or-later",
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `repository` metadata to `package.json`
- set `repository.url` to `https://github.com/unsalted/ether-to-astro`

## Why
Release publish failed with:
`Error verifying sigstore provenance bundle ... repository.url is "", expected to match https://github.com/unsalted/ether-to-astro`

## Validation
- npm run build
- npm run lint
