### PR TITLE
docs(agents): tighten risk, review, and release guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Purpose
-This file is for coding agents working in `astro-mcp`. It documents the real architecture and safe change workflow so edits stay correct and low-risk.
+This file is for coding agents working in `ether-to-astro`. It documents the real architecture and safe change workflow so edits stay correct, low-risk, and release-safe.
 
 ## Current Runtime Facts
 - Engine is native Node binding: `sweph` (not WASM/WASI).
@@ -68,7 +68,14 @@ Defined in `tests/validation/utils/tolerances.ts`:
 - `EphemerisCalculator.findExactTransitTimes()` in `src/ephemeris.ts`.
 - Transit root-selection policy in `src/transits.ts`.
 - Time conversion/disambiguation in `src/time-utils.ts`.
+- CLI/MCP surface drift between `src/cli.ts`, `src/index.ts`, and `src/astro-service.ts`.
+- Packaging / bin / publish behavior for `e2a` and `e2a-mcp`.
 - Capability checks and comparator severity in validation harness.
+
+## Review Priority Ladder
+- **P1** - Wrong astro math, wrong timezone/DST handling, wrong transit/root behavior, CLI/MCP contract drift, packaging/bin/publish breakage, or validation regressions that could ship incorrect results.
+- **P2** - Missing or weak tests for high-risk changes, docs/help-text drift, profile resolution regressions, or changes that make validation/debugging harder.
+- **P3** - Style, cleanup, wording, and low-risk refactors with no behavioral impact.
 
 ## Safe Change Workflow
 1. Make focused edits (avoid broad refactors).
@@ -86,6 +93,8 @@ Defined in `tests/validation/utils/tolerances.ts`:
 - Routine merge gate is `npm run build`, `npm run lint`, and `npm test -- --run`.
 - `npm run validate:astro` is targeted validation, not the default gate for every change.
 - Biome is the source of truth for formatting, import order, and linting.
+- CLI profile resolution is adapter-only behavior; do not leak `.astro.json`, `--profile`, or profile-file semantics into MCP tool contracts.
+- `src/astro-service.ts` is the shared behavior layer; prefer fixing logic there before adding surface-specific patches in CLI or MCP.
 - Preferred commit types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `build`, `ci`.
 - Keep commits scoped to one coherent change whenever possible.
 
@@ -102,9 +111,13 @@ Defined in `tests/validation/utils/tolerances.ts`:
 
 ## Known Gotchas
 - `sweph` has process-wide settings (e.g., ephemeris path); avoid per-request mutation.
+- In the normal Node runtime, rise/set and eclipse functionality are expected to work. Treat breakage there as a real regression, not as optional capability drift.
+- `get_server_status` is the source of truth for loaded-chart state on the MCP side. Do not invent parallel state reporting elsewhere.
 
 ## Agent Style for This Repo
 - Prefer minimal, typed, fixture-driven changes.
 - Keep adapter normalization stable when comparing outputs.
 - Do not mask solver regressions with broad dedupe/tolerance changes.
 - Keep external CLI parity optional and auto-skippable.
+- If changing command/tool signatures, update all three together: schema/help text, implementation, and tests.
+- For release-facing changes, check README/help text/package metadata for drift.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ npm run build
 {
   "mcpServers": {
     "astro": {
-      "command": "e2a-mcp"
+      "command": "npx",
+      "args": ["--yes", "--package=ether-to-astro", "e2a-mcp"]
     }
   }
 }
@@ -158,17 +159,27 @@ This design is **MCP-compliant** for stdio transport and ensures complete isolat
 
 `e2a` is JSON-first for agent usage and supports `--pretty` for human-readable output.
 
+`npx` usage note: this package is named `ether-to-astro`, so invoke bins with `--package`.
+
+Install globally if you want direct commands without `--package`:
+
+```bash
+npm install -g ether-to-astro
+e2a --help
+e2a-mcp --help
+```
+
 Examples:
 
 ```bash
 # Help
-npx e2a --help
+npx --yes --package=ether-to-astro e2a --help
 
 # Set natal chart and print JSON
-npx e2a set-natal-chart --name "Test" --year 1990 --month 1 --day 1 --hour 12 --minute 0 --latitude 40.7 --longitude -74.0 --timezone America/New_York
+npx --yes --package=ether-to-astro e2a set-natal-chart --name "Test" --year 1990 --month 1 --day 1 --hour 12 --minute 0 --latitude 40.7 --longitude -74.0 --timezone America/New_York
 
 # Human-readable transit output
-npx e2a get-transits --natal-file ./natal.json --date 2026-03-27 --pretty
+npx --yes --package=ether-to-astro e2a get-transits --natal-file ./natal.json --date 2026-03-27 --pretty
 ```
 
 ### CLI Profiles (`.astro.json`)
@@ -193,9 +204,9 @@ Profile name resolution order:
 Read-only helper commands:
 
 ```bash
-npx e2a profiles list
-npx e2a profiles show --profile elwyn
-npx e2a profiles validate
+npx --yes --package=ether-to-astro e2a profiles list
+npx --yes --package=ether-to-astro e2a profiles show --profile default
+npx --yes --package=ether-to-astro e2a profiles validate
 ```
 
 Recommended: add project-local `.astro.json` to `.gitignore` because it contains birth data.


### PR DESCRIPTION
## Summary
- tighten AGENTS.md high-risk change guidance
- add review priority ladder (P1/P2/P3)
- clarify CLI/MCP boundary and shared-service expectations
- add release-facing drift checks and known gotchas

## Why
Codifies the operating rules we aligned on during release/debug cycles so future agent edits are safer and more consistent.
