### PR TITLE
build(dependabot): ignore @types/node semver-major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       time: "09:00"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: build
       include: scope


### PR DESCRIPTION
### Motivation
- Dependabot was producing semver-major bumps for `@types/node` that can expose Node 25-only typings while the project declares `engines.node >=22`, risking type-checked but runtime-unsupported API usage.

### Description
- Add an `ignore` rule to `.github/dependabot.yml` to skip `version-update:semver-major` updates for `@types/node` so Dependabot will continue to open minor/patch updates but not major bumps.

### Testing
- Ran `npm run lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c76fa7617883249e93ec96bd5effac)