### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -7,7 +7,7 @@
 ```
 
 This will:
-1. Install npm dependencies (including WebAssembly Swiss Ephemeris)
+1. Install npm dependencies (including native `sweph`)
 2. Build TypeScript to JavaScript
 
 ## Add to Claude Desktop
@@ -22,14 +22,24 @@ Add this MCP server:
 {
   "mcpServers": {
     "astro": {
-      "command": "node",
-      "args": ["/path/to/ether-to-astro-mcp/dist/index.js"]
+      "command": "npx",
+      "args": ["--yes", "--package=ether-to-astro", "e2a-mcp"]
     }
   }
 }
 ```
 
-**Important**: Replace `/path/to/ether-to-astro-mcp` with your actual path!
+Alternative (after global install):
+
+```json
+{
+  "mcpServers": {
+    "astro": {
+      "command": "e2a-mcp"
+    }
+  }
+}
+```
 
 ## First Use
 
@@ -55,16 +65,18 @@ When will the Moon conjunct my Venus be exact?
 ## MCP Tools Available
 
 - `set_natal_chart` - Store birth data
-- `get_daily_transits` - Current planetary positions
-- `get_moon_transits` - Moon aspects to natal planets
-- `get_personal_planet_transits` - Sun/Mercury/Venus/Mars aspects
-- `get_outer_planet_transits` - Jupiter/Saturn/Uranus/Neptune/Pluto aspects
-- `get_exact_transit_times` - Calculate exact times for current transits
-- `get_upcoming_transits` - Multi-day forecast (default 7 days)
+- `get_transits` - Category-filtered transit analysis with optional exact-time data
+- `get_houses` - House cusps plus angles (ASC/MC)
+- `get_retrograde_planets` - Current retrograde status
+- `get_rise_set_times` - Rise/set and meridian events
+- `get_asteroid_positions` - Asteroids and nodes
+- `get_next_eclipses` - Next solar/lunar eclipses
+- `generate_natal_chart` - Render natal chart (SVG/PNG/WebP)
+- `generate_transit_chart` - Render transit chart (SVG/PNG/WebP)
+- `get_server_status` - MCP-side loaded-chart and service status
 
 ## Technical Notes
 
-- Uses WebAssembly Swiss Ephemeris (no native compilation!)
-- Moshier mode provides ~1 arcsecond precision
-- No ephemeris data files needed
-- Works on Mac/Linux (Node.js required)
+- Uses native `sweph` bindings for Swiss Ephemeris calculations
+- Ephemeris files are downloaded/configured during install
+- Works on macOS/Linux (Node.js 22+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ether-to-astro",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ether-to-astro",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ether-to-astro",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Local-first astrology toolkit with a CLI (e2a) and MCP server (e2a-mcp) for charts, transits, rendering, and agent workflows.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package version from `1.0.2` to `1.1.0`
- refresh `SETUP.md` to current runtime and command surfaces:
  - native `sweph` (not WASM wording)
  - `npx --package=ether-to-astro e2a-mcp` setup path
  - current MCP tool names
  - Node 22+ note

## Why
- package docs have evolved significantly; this cut ensures npm consumers get the latest README/setup docs and metadata in a single clean release.

## Validation
- docs/version change only
