### PR TITLE
feat(mcp): add electional context primitives to get_transits

### DIFF
--- a/src/astro-service.ts
+++ b/src/astro-service.ts
@@ -17,6 +17,7 @@ import {
   OUTER_PLANETS,
   PERSONAL_PLANETS,
   PLANETS,
+  type PlanetPosition,
   type PlanetPositionResponse,
   type Transit,
   type TransitResponse,
@@ -52,6 +53,8 @@ export interface GetTransitsInput {
   date?: string;
   categories?: string[];
   include_mundane?: boolean;
+  include_electional_context?: boolean;
+  electional_context_fields?: string[];
   days_ahead?: number;
   max_orb?: number;
   exact_only?: boolean;
@@ -296,6 +299,8 @@ export class AstroService {
     const dateStr = input.date;
     const categories = input.categories ?? ['all'];
     const includeMundane = input.include_mundane ?? false;
+    const includeElectionalContext = input.include_electional_context ?? false;
+    const electionalContextFields = input.electional_context_fields ?? [];
     const daysAhead = input.days_ahead ?? 0;
     const maxOrb = input.max_orb ?? 8;
     const exactOnly = input.exact_only ?? false;
@@ -380,22 +385,43 @@ export class AstroService {
       unknown
     >;
     let mundaneText = '';
+    const targetJD = this.ephem.dateToJulianDay(targetDate);
+    const currentPositions = this.ephem.getAllPlanets(targetJD, Object.values(PLANETS));
+    const electionalContext = includeElectionalContext
+      ? this.buildElectionalContext(
+          natalChart,
+          structuredData,
+          currentPositions,
+          targetJD,
+          timezone,
+          electionalContextFields
+        )
+      : undefined;
 
     if (includeMundane) {
-      const currentJD = this.ephem.dateToJulianDay(targetDate);
-      const currentPositions = this.ephem.getAllPlanets(currentJD, transitingPlanetIds);
+      const mundanePositions = currentPositions.filter((p) =>
+        transitingPlanetIds.includes(p.planetId)
+      );
       const mundaneData: PlanetPositionResponse = {
         date: dateLabel,
         timezone,
-        positions: currentPositions,
+        positions: mundanePositions,
       };
       responseData = { transits: structuredData, mundane: mundaneData };
+      if (electionalContext) {
+        responseData.electionalContext = electionalContext;
+      }
       mundaneText = `\n\nCurrent Planetary Positions:\n\n${currentPositions
         .map(
           (p) =>
             `${p.planet}: ${p.degree.toFixed(1)}° ${p.sign} (${p.isRetrograde ? 'Rx' : 'Direct'})`
         )
         .join('\n')}`;
+    } else if (electionalContext) {
+      responseData = {
+        ...responseData,
+        electionalContext,
+      };
     }
 
     const humanLines = filteredTransits
@@ -416,6 +442,135 @@ export class AstroService {
       data: responseData,
       text: transitHeader + mundaneText,
     };
+  }
+
+  private buildElectionalContext(
+    natalChart: NatalChart,
+    transitResponse: TransitResponse,
+    currentPositions: PlanetPosition[],
+    targetJD: number,
+    timezone: string,
+    requestedFields: string[]
+  ): Record<string, unknown> {
+    const includeField = (field: string): boolean =>
+      requestedFields.length === 0 || requestedFields.includes(field);
+
+    const houses = this.houseCalc.calculateHouses(
+      targetJD,
+      natalChart.location.latitude,
+      natalChart.location.longitude,
+      natalChart.houseSystem || 'P'
+    );
+    const moon = currentPositions.find((p) => p.planet === 'Moon');
+    const sun = currentPositions.find((p) => p.planet === 'Sun');
+    const ascSign = ZODIAC_SIGNS[Math.floor(houses.ascendant / 30)];
+    const ascRuler = this.getAscendantRuler(ascSign);
+    const ascRulerPosition = currentPositions.find((p) => p.planet === ascRuler);
+    const moonHouse = moon ? this.resolveHouse(houses.cusps, moon.longitude) : undefined;
+    const sunHouse = sun ? this.resolveHouse(houses.cusps, sun.longitude) : undefined;
+
+    const context: Record<string, unknown> = {};
+
+    if (includeField('moon_condition')) {
+      context.moonCondition = moon
+        ? {
+            sign: moon.sign,
+            degree: moon.degree,
+            house: moonHouse,
+            isRetrograde: moon.isRetrograde,
+            phaseDegreesFromSun: sun
+              ? Number.parseFloat(this.angularDifference(moon.longitude, sun.longitude).toFixed(2))
+              : undefined,
+          }
+        : null;
+    }
+
+    if (includeField('applying_aspects')) {
+      context.applyingAspects = transitResponse.transits.map((transit) => ({
+        ...transit,
+        applyingState: transit.isApplying ? 'applying' : 'separating',
+      }));
+    }
+
+    if (includeField('house_context')) {
+      context.houseContext = {
+        system: houses.system,
+        ascendant: houses.ascendant,
+        mc: houses.mc,
+      };
+    }
+
+    if (includeField('asc_sign')) {
+      context.ascSign = ascSign;
+    }
+
+    if (includeField('ruler_condition')) {
+      context.rulerCondition = ascRulerPosition
+        ? {
+            ruler: ascRuler,
+            sign: ascRulerPosition.sign,
+            degree: ascRulerPosition.degree,
+            house: this.resolveHouse(houses.cusps, ascRulerPosition.longitude),
+            isRetrograde: ascRulerPosition.isRetrograde,
+            speed: ascRulerPosition.speed,
+          }
+        : null;
+    }
+
+    if (includeField('sect_relevant_inputs')) {
+      const isDayChart = sunHouse !== undefined && sunHouse >= 7 && sunHouse <= 12;
+      context.sectRelevantInputs = {
+        isDayChart,
+        sectLight: isDayChart ? 'Sun' : 'Moon',
+        sunHouse,
+        moonHouse,
+        chartTimezone: timezone,
+      };
+    }
+
+    return context;
+  }
+
+  private resolveHouse(cusps: number[], longitude: number): number {
+    const cuspList = cusps.slice(1, 13);
+    for (let i = 0; i < cuspList.length; i++) {
+      const start = cuspList[i];
+      const end = cuspList[(i + 1) % cuspList.length];
+      if (this.isLongitudeInArc(longitude, start, end)) {
+        return i + 1;
+      }
+    }
+    return 1;
+  }
+
+  private isLongitudeInArc(value: number, start: number, end: number): boolean {
+    if (start <= end) {
+      return value >= start && value < end;
+    }
+    return value >= start || value < end;
+  }
+
+  private angularDifference(a: number, b: number): number {
+    const raw = Math.abs(a - b) % 360;
+    return raw > 180 ? 360 - raw : raw;
+  }
+
+  private getAscendantRuler(sign: string): PlanetPosition['planet'] {
+    const rulerBySign: Record<string, PlanetPosition['planet']> = {
+      Aries: 'Mars',
+      Taurus: 'Venus',
+      Gemini: 'Mercury',
+      Cancer: 'Moon',
+      Leo: 'Sun',
+      Virgo: 'Mercury',
+      Libra: 'Venus',
+      Scorpio: 'Mars',
+      Sagittarius: 'Jupiter',
+      Capricorn: 'Saturn',
+      Aquarius: 'Saturn',
+      Pisces: 'Jupiter',
+    };
+    return rulerBySign[sign] ?? 'Mars';
   }
 
   getHouses(

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -113,6 +113,27 @@ export const MCP_TOOL_SPECS: ToolSpec[] = [
           description:
             'Include current planetary positions (not transits to natal chart). Defaults to false.',
         },
+        include_electional_context: {
+          type: 'boolean',
+          description:
+            'Include raw electional context primitives (moon condition, applying aspects, house context, asc sign, ruler condition, sect inputs). Defaults to false.',
+        },
+        electional_context_fields: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [
+              'moon_condition',
+              'applying_aspects',
+              'house_context',
+              'asc_sign',
+              'ruler_condition',
+              'sect_relevant_inputs',
+            ],
+          },
+          description:
+            'Optional subset of electional context fields to include. Defaults to all supported fields when include_electional_context is true.',
+        },
         days_ahead: {
           type: 'number',
           description:
@@ -141,6 +162,8 @@ export const MCP_TOOL_SPECS: ToolSpec[] = [
         date: args.date as string | undefined,
         categories: args.categories as string[] | undefined,
         include_mundane: args.include_mundane as boolean | undefined,
+        include_electional_context: args.include_electional_context as boolean | undefined,
+        electional_context_fields: args.electional_context_fields as string[] | undefined,
         days_ahead: args.days_ahead as number | undefined,
         max_orb: args.max_orb as number | undefined,
         exact_only: args.exact_only as boolean | undefined,

--- a/tests/unit/astro-service.test.ts
+++ b/tests/unit/astro-service.test.ts
@@ -205,6 +205,42 @@ describe('When using AstroService', () => {
     });
   });
 
+  it('Given electional context is requested, then getTransits returns raw electional primitives', () => {
+    const { service } = makeService();
+    const result = service.getTransits(makeNatalChart(), {
+      include_electional_context: true,
+    });
+    expect(result.data).toHaveProperty('electionalContext');
+    expect((result.data as any).electionalContext).toMatchObject({
+      moonCondition: expect.any(Object),
+      applyingAspects: expect.any(Array),
+      houseContext: expect.any(Object),
+      ascSign: expect.any(String),
+      rulerCondition: expect.any(Object),
+      sectRelevantInputs: expect.any(Object),
+    });
+  });
+
+  it('Given electional applying aspects are included, then each aspect carries explicit applying state', () => {
+    const { service } = makeService();
+    const result = service.getTransits(makeNatalChart(), {
+      include_electional_context: true,
+      electional_context_fields: ['applying_aspects'],
+    });
+    const applying = (result.data as any).electionalContext.applyingAspects;
+    expect(applying).toHaveLength(1);
+    expect(applying[0]).toMatchObject({
+      isApplying: true,
+      applyingState: 'applying',
+    });
+  });
+
+  it('Given electional context is not requested, then getTransits remains backward compatible', () => {
+    const { service } = makeService();
+    const result = service.getTransits(makeNatalChart(), {});
+    expect((result.data as any).electionalContext).toBeUndefined();
+  });
+
   it('Given a natal chart location, then getRiseSetTimes returns ISO payload and readable text', async () => {
     const { service, riseSetCalc } = makeService();
     const result = await service.getRiseSetTimes(makeNatalChart());

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -58,6 +58,42 @@ describe('When resolving tool specs from the registry', () => {
     expect(service.getServerStatus).toHaveBeenCalled();
   });
 
+  it('Given get_transits schema, then electional context flags are exposed in the tool contract', () => {
+    const spec = getToolSpec('get_transits');
+    expect(spec).toBeDefined();
+    const schema = spec?.inputSchema as any;
+    expect(schema.properties.include_electional_context?.type).toBe('boolean');
+    expect(schema.properties.electional_context_fields?.items?.enum).toEqual(
+      expect.arrayContaining([
+        'moon_condition',
+        'applying_aspects',
+        'house_context',
+        'asc_sign',
+        'ruler_condition',
+        'sect_relevant_inputs',
+      ])
+    );
+  });
+
+  it('Given get_transits execution with electional args, then args are forwarded to AstroService.getTransits', async () => {
+    const service = makeService();
+    await getToolSpec('get_transits')!.execute(
+      { service: service as any, natalChart: { name: 'chart' } as any },
+      {
+        include_electional_context: true,
+        electional_context_fields: ['moon_condition', 'asc_sign'],
+      }
+    );
+
+    expect(service.getTransits).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        include_electional_context: true,
+        electional_context_fields: ['moon_condition', 'asc_sign'],
+      })
+    );
+  });
+
   it('Given async state tool handlers, then they resolve to state payloads', async () => {
     const service = makeService();
     const ctx = { service: service as any, natalChart: { name: 'chart' } as any };


### PR DESCRIPTION
### Motivation

- Expose raw electional primitives (moon condition, applying aspects, house context, ASC sign, ruler condition, sect inputs) from the MCP `get_transits` surface so skills can evaluate windows without embedding electional policy.
- Keep decision logic out of MCP and return deterministic, structured inputs rather than ranked/judgmental labels.
- Extend the existing `get_transits` contract instead of adding a new specialized tool to avoid tool proliferation and maintain API consistency.

### Description

- Extended the `get_transits` tool schema with `include_electional_context` (boolean) and `electional_context_fields` (optional enum array) in `src/tool-registry.ts` and plumbed the args through execution to `AstroService.getTransits`.
- Added `include_electional_context` and `electional_context_fields` to the `GetTransitsInput` interface in `src/astro-service.ts` and wired conditional generation of an `electionalContext` payload only when requested.
- Implemented `buildElectionalContext` with deterministic, raw primitives: `moonCondition`, `applyingAspects` (with explicit `applyingState`), `houseContext`, `ascSign`, `rulerCondition`, and `sectRelevantInputs` plus helper utilities (`resolveHouse`, `isLongitudeInArc`, `angularDifference`, `getAscendantRuler`).
- Preserved backward compatibility by returning `electionalContext` only when `include_electional_context` is true and by not changing existing default behavior or transit semantics.
- Added unit tests covering tool schema exposure and arg forwarding, service-level electional context shape, applying-aspect semantics, and no-flag compatibility in `tests/unit/tool-registry.test.ts` and `tests/unit/astro-service.test.ts`.

### Testing

- Ran unit tests: `npm test -- --run` and targeted runs for updated tests; all tests passed (224 tests across test suite in local run).
- Type check and build: `npm run build` succeeded.
- Lint/format: `npm run lint` (Biome) succeeded and auto-fixed import ordering where needed.
- Full validation commands executed locally: `npm run build`, `npm run lint`, and `npm test -- --run`, all passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c830c1d48483249fcdf57e782d75e0)