### PR TITLE
[codex] clarify skill incubation boundaries in product docs

### DIFF
--- a/docs/product/architecture-boundaries.md
+++ b/docs/product/architecture-boundaries.md
@@ -121,6 +121,10 @@ Skills should:
 
 The default target is a one-call or two-call skill flow.
 
+Skill-layer examples in this repo are primarily boundary examples and workflow incubators.
+
+They should not be read as automatic commitments to build or maintain every listed workflow as a first-class product artifact.
+
 ### Good Skill Flow
 
 1. Call forecast primitives.
@@ -199,7 +203,7 @@ Based on the current product direction:
 - electional primitives
 - rising-sign window helpers
 
-### Strong candidates for skills
+### Candidate workflow experiments after primitive stabilization
 
 - daily brief generation
 - weekly overview synthesis

--- a/docs/product/product-tenets.md
+++ b/docs/product/product-tenets.md
@@ -71,6 +71,12 @@ Examples:
 - electional scoring using a specific user’s preferences
 - preference-aware section ordering and tone
 
+Skill ideas are the default incubation layer for new workflow concepts.
+
+That does not make every skill example in this repo a committed product roadmap item.
+
+Treat skill-layer examples and issue ideas as candidate workflows unless they are explicitly promoted into committed work.
+
 ### MCP Prompts Own
 
 Use MCP prompts as thin, discoverable entry points into common workflows.
@@ -114,6 +120,8 @@ Examples:
 ## Promotion Rule
 
 New workflow ideas should start life as skills or prompts.
+
+That is an incubation step, not an automatic commitment to ship a repo-owned skill or workflow.
 
 They should graduate into MCP only when:
 


### PR DESCRIPTION
## Summary

This PR tightens the public product-boundary docs so skill-layer examples are read as workflow incubation, not automatic roadmap commitments.

## What changed

- clarified in `docs/product/product-tenets.md` that skill ideas are the default incubation layer for workflow concepts
- made explicit that skill examples and issue ideas are candidate workflows unless they are intentionally promoted into committed work
- updated `docs/product/architecture-boundaries.md` to describe skill-layer examples as boundary examples / workflow incubators
- renamed the repo-implications section from “strong candidates for skills” to “candidate workflow experiments after primitive stabilization”

## Why

The current docs are directionally correct on MCP vs skill boundaries, but they read a little too much like every skill-layer example is a committed product deliverable. Tightening that wording should make issue triage and future agent handoffs less likely to overshoot the roadmap.

## Validation

- docs-only change
- no tests run