### PR TITLE
[codex] add v1.2.0 draft release notes

### DIFF
--- a/docs/releases/1.2.0-draft.md
+++ b/docs/releases/1.2.0-draft.md
@@ -1,0 +1,48 @@
+# ether-to-astro v1.2.0
+
+Suggested release type: `minor`
+
+This release improves transit forecasting, adds new electional and rising-sign primitives, and tightens a few important MCP and timezone edge cases. 🎉
+
+## 1.2.0 (2026-03-29)
+
+### New feature
+
+- add explicit `snapshot`, `best_hit`, and `forecast` transit modes with day-grouped forecast output
+- add sign, degree, and house metadata directly to transit responses for both transit and natal sides
+- add mundane transit-to-transit aspects and supportive/challenging weather output for date and date-range queries
+- add standalone `get_electional_context` for deterministic electional snapshots without requiring a loaded natal chart 🌙
+- add rising-sign window helpers for date and location queries, with approximate and exact modes ⬆️
+- add deterministic MCP startup defaults for reporting and make `e2a --mcp` the canonical MCP entrypoint
+
+### Bug fix
+
+- keep forecast labels and exact-time rendering aligned with the reporting timezone
+- preserve `e2a-mcp` compatibility behavior when launched through bin shims and wrapper paths
+- reject DST-ambiguous or nonexistent local electional times instead of silently normalizing them
+- fix applying-aspect edge cases in electional context, especially for faster-moving bodies
+
+### Documentation Changes
+
+- update docs and setup guidance around the unified `e2a` CLI and MCP entrypoint
+- add repo-owned workflow skills and skill authoring guidance
+- clarify MCP vs skill product boundaries in repo docs
+
+### ⚙️ Chore
+
+- refresh product governance and contributor guidance for issue triage and release workflow
+
+## Upgrade notes
+
+- prefer `e2a --mcp` for MCP launches
+- `e2a-mcp` remains available as a compatibility alias
+- if you consume transit output programmatically, prefer explicit `mode` values over relying on legacy `days_ahead` behavior
+
+## Included PRs
+
+- #32 add rising-sign window helper
+- #34 add mundane transit-to-transit aspects and weather output
+- #38 unify `e2a` entrypoint for CLI and MCP
+- #40 clarify transit mode contract
+- #41 preserve alias mode and reporting timezone consistency
+- #43 fix electional DST and applying-aspect edge cases


### PR DESCRIPTION
## Summary
- add a draft release-notes document for the next release under `docs/releases/1.2.0-draft.md`
- rewrite the draft into a more standard GitHub release-notes structure
- keep the scope to release-note prep only

## Why
We wanted a release-ready draft that reads more like real project release notes and less like internal product copy, while keeping the work easy to review and reuse for the eventual GitHub Release.

## Impact
Maintainers now have a committed draft release body to refine or paste into the eventual release flow.

## Validation
- docs-only change
- no tests run