### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ether-to-astro",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ether-to-astro",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ether-to-astro",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Local-first astrology toolkit with a unified e2a binary for CLI and MCP workflows, plus an e2a-mcp compatibility alias.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package version from `1.1.0` to `1.2.0`
- create the `v1.2.0` tag for the next release
- keep the release-notes draft already merged to `main` as the source for the GitHub Release body

## Why
Recent merged work adds enough new MCP and CLI capability to justify a minor release, but branch protection requires the version-bump commit itself to land through a pull request.

## Validation
- `npm version minor`
- release commit generated from a clean checkout of `main`

## Notes
- release should be published from the existing `v1.2.0` tag after this PR merges
- this PR should be merged without squashing so the tagged commit remains in `main` history