### PR TITLE
refactor(astro-service): extract electional workflows

### DIFF
--- a/src/astro-service.ts
+++ b/src/astro-service.ts
@@ -1,6 +1,7 @@
 import { writeFile } from 'node:fs/promises';
-import { Temporal } from '@js-temporal/polyfill';
 import { parseDateOnlyInput } from './astro-service/date-input.js';
+import { ElectionalService } from './astro-service/electional-service.js';
+import { RisingSignService } from './astro-service/rising-sign-service.js';
 import { resolveHouseSystem, resolveReportingTimezone } from './astro-service/shared.js';
 import { TransitService } from './astro-service/transit-service.js';
 import { ChartRenderer } from './charts.js';
@@ -11,27 +12,15 @@ import { EphemerisCalculator } from './ephemeris.js';
 import { formatDateOnly, formatInTimezone } from './formatter.js';
 import { HouseCalculator } from './houses.js';
 import { RiseSetCalculator } from './riseset.js';
-import {
-  addLocalDays,
-  type Disambiguation,
-  formatLocalTimestampWithOffset,
-  localToUTC,
-  utcToLocal,
-} from './time-utils.js';
+import { type Disambiguation, localToUTC, utcToLocal } from './time-utils.js';
 import { TransitCalculator } from './transits.js';
 import {
-  ASPECTS,
   ASTEROIDS,
-  type ElectionalAspect,
-  type ElectionalContextResponse,
   type ElectionalHouseSystem,
-  type ElectionalPhaseName,
   type HouseSystem,
   type NatalChart,
   NODES,
   PLANETS,
-  type PlanetName,
-  type PlanetPosition,
   ZODIAC_SIGNS,
 } from './types.js';
 
@@ -124,44 +113,6 @@ interface ChartServiceResult {
 
 export { parseDateOnlyInput } from './astro-service/date-input.js';
 
-function parseTimeOnlyInput(timeStr: string): { hour: number; minute: number; second: number } {
-  const match = /^(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(timeStr);
-  if (!match) {
-    throw new Error(`Invalid time format: expected HH:mm[:ss], got "${timeStr}"`);
-  }
-
-  const hour = Number(match[1]);
-  const minute = Number(match[2]);
-  const second = match[3] === undefined ? 0 : Number(match[3]);
-
-  if (hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59) {
-    throw new Error(`Invalid clock time: ${timeStr}`);
-  }
-
-  try {
-    Temporal.PlainTime.from({ hour, minute, second });
-  } catch {
-    throw new Error(`Invalid clock time: ${timeStr}`);
-  }
-
-  return { hour, minute, second };
-}
-
-const ELECTIONAL_CONTEXT_PLANET_IDS = [
-  PLANETS.SUN,
-  PLANETS.MOON,
-  PLANETS.MERCURY,
-  PLANETS.VENUS,
-  PLANETS.MARS,
-  PLANETS.JUPITER,
-  PLANETS.SATURN,
-  PLANETS.URANUS,
-  PLANETS.NEPTUNE,
-  PLANETS.PLUTO,
-];
-
-const ELECTIONAL_CONTEXT_HOUSE_SYSTEMS: ElectionalHouseSystem[] = ['P', 'K', 'W', 'R'];
-
 /**
  * Shared service facade used by both the MCP server and the CLI.
  *
@@ -178,6 +129,8 @@ export class AstroService {
   readonly chartRenderer: ChartRenderer;
   readonly mcpStartupDefaults: Readonly<McpStartupDefaults>;
   private readonly transitService: TransitService;
+  private readonly electionalService: ElectionalService;
+  private readonly risingSignService: RisingSignService;
   private readonly now: () => Date;
   private readonly writeFileFn: (
     path: string,
@@ -202,6 +155,14 @@ export class AstroService {
       mcpStartupDefaults: this.mcpStartupDefaults,
       now: this.now,
       formatTimestamp: this.formatTimestamp.bind(this),
+    });
+    this.electionalService = new ElectionalService({
+      ephem: this.ephem,
+      houseCalc: this.houseCalc,
+    });
+    this.risingSignService = new RisingSignService({
+      ephem: this.ephem,
+      houseCalc: this.houseCalc,
     });
   }
 
@@ -386,199 +347,7 @@ export class AstroService {
    * Produce deterministic electional context for a single local instant.
    */
   getElectionalContext(input: GetElectionalContextInput): ServiceResult<Record<string, unknown>> {
-    if (input.latitude < -90 || input.latitude > 90) {
-      throw new Error(`Invalid latitude: ${input.latitude} (must be between -90 and 90)`);
-    }
-    if (input.longitude < -180 || input.longitude > 180) {
-      throw new Error(`Invalid longitude: ${input.longitude} (must be between -180 and 180)`);
-    }
-
-    const houseSystem = input.house_system ?? 'P';
-    if (!ELECTIONAL_CONTEXT_HOUSE_SYSTEMS.includes(houseSystem)) {
-      throw new Error(
-        `Invalid house_system: ${houseSystem} (must be one of ${ELECTIONAL_CONTEXT_HOUSE_SYSTEMS.join(', ')})`
-      );
-    }
-
-    const includeRulerBasics = input.include_ruler_basics ?? false;
-    const includePlanetaryApplications = input.include_planetary_applications ?? true;
-    const orbDegrees = input.orb_degrees ?? 3;
-    if (!Number.isFinite(orbDegrees) || orbDegrees < 0.1 || orbDegrees > 10) {
-      throw new Error(`Invalid orb_degrees: ${orbDegrees} (must be between 0.1 and 10)`);
-    }
-
-    const parsedDate = parseDateOnlyInput(input.date);
-    const parsedTime = parseTimeOnlyInput(input.time);
-    let instantUtc: Date;
-    try {
-      instantUtc = localToUTC(
-        {
-          year: parsedDate.year,
-          month: parsedDate.month,
-          day: parsedDate.day,
-          hour: parsedTime.hour,
-          minute: parsedTime.minute,
-          second: parsedTime.second,
-        },
-        input.timezone,
-        'reject'
-      );
-    } catch (error) {
-      if (error instanceof RangeError) {
-        throw new Error(
-          `Invalid local electional time: ${input.date} ${input.time} in ${input.timezone} is ambiguous or nonexistent due to a DST transition.`
-        );
-      }
-      throw error;
-    }
-    const jdUt = this.ephem.dateToJulianDay(instantUtc);
-    const houses = this.houseCalc.calculateHouses(
-      jdUt,
-      input.latitude,
-      input.longitude,
-      houseSystem
-    );
-    const positions = this.ephem.getAllPlanets(jdUt, ELECTIONAL_CONTEXT_PLANET_IDS);
-
-    const sun = positions.find((position) => position.planet === 'Sun');
-    const moon = positions.find((position) => position.planet === 'Moon');
-    if (!sun || !moon) {
-      throw new Error('Ephemeris failed to compute Sun/Moon positions for electional context.');
-    }
-
-    const sunHorizontal = this.ephem.getHorizontalCoordinates(
-      jdUt,
-      sun,
-      input.longitude,
-      input.latitude
-    );
-    const sunAltitudeDegrees = Number.parseFloat(sunHorizontal.trueAltitude.toFixed(2));
-    const isDayChart = sunAltitudeDegrees >= 0;
-
-    const applyingAspects = includePlanetaryApplications
-      ? this.getElectionalApplyingAspects(positions, orbDegrees)
-      : undefined;
-    const moonApplyingAspects = applyingAspects?.filter(
-      (aspect) => aspect.from_body === 'Moon' || aspect.to_body === 'Moon'
-    );
-
-    const phaseAngle = Number.parseFloat(
-      ((((moon.longitude - sun.longitude) % 360) + 360) % 360).toFixed(2)
-    );
-    const warnings: string[] = [];
-    if (Math.abs(sunAltitudeDegrees) < 0.5) {
-      warnings.push('Sun is near the horizon; day/night classification is close to the boundary.');
-    }
-    warnings.push('Moon void-of-course is deferred in this slice and returns null.');
-    if (houses.system !== houseSystem) {
-      warnings.push(
-        `House calculation fell back from ${houseSystem} to ${houses.system} for this location.`
-      );
-    }
-
-    const ascLongitude = ((houses.ascendant % 360) + 360) % 360;
-    const ascSign = ZODIAC_SIGNS[Math.floor(ascLongitude / 30)];
-    const response: ElectionalContextResponse = {
-      input: {
-        date: input.date,
-        time: input.time,
-        timezone: input.timezone,
-        latitude: input.latitude,
-        longitude: input.longitude,
-        house_system: houses.system as ElectionalHouseSystem,
-        instant_utc: instantUtc.toISOString(),
-        jd_ut: Number.parseFloat(jdUt.toFixed(8)),
-      },
-      ascendant: {
-        longitude: Number.parseFloat(ascLongitude.toFixed(4)),
-        sign: ascSign,
-        degree_in_sign: Number.parseFloat((ascLongitude % 30).toFixed(4)),
-      },
-      sect: {
-        is_day_chart: isDayChart,
-        sun_altitude_degrees: sunAltitudeDegrees,
-        classification: isDayChart ? 'day' : 'night',
-      },
-      moon: {
-        longitude: Number.parseFloat(moon.longitude.toFixed(4)),
-        sign: moon.sign,
-        phase_angle: phaseAngle,
-        phase_name: this.getElectionalPhaseName(phaseAngle),
-        is_void_of_course: null,
-        ...(moonApplyingAspects !== undefined ? { applying_aspects: moonApplyingAspects } : {}),
-      },
-      meta: {
-        deterministic: true,
-        requires_natal: false,
-        warnings,
-        deferred_features: [
-          'robust_void_of_course',
-          'detailed_ruler_condition',
-          'house_context',
-          'natal_overlays',
-        ],
-      },
-    };
-
-    if (applyingAspects) {
-      response.applying_aspects = applyingAspects;
-    }
-
-    if (includeRulerBasics) {
-      const rulerBody = this.getTraditionalSignRuler(ascSign);
-      const rulerPosition = positions.find((position) => position.planet === rulerBody);
-      if (!rulerPosition) {
-        throw new Error(`Ephemeris failed to compute ASC ruler position for ${rulerBody}.`);
-      }
-      response.ruler_basics = {
-        asc_sign_ruler: {
-          body: rulerBody,
-          longitude: Number.parseFloat(rulerPosition.longitude.toFixed(4)),
-          sign: rulerPosition.sign,
-          speed: Number.parseFloat(rulerPosition.speed.toFixed(6)),
-          is_retrograde: rulerPosition.isRetrograde,
-        },
-      };
-    }
-
-    const humanText = [
-      `Electional context for ${input.date} ${input.time} (${input.timezone})`,
-      '',
-      `Ascendant: ${response.ascendant.degree_in_sign.toFixed(2)}° ${response.ascendant.sign}`,
-      `Sect: ${response.sect.classification} (${response.sect.sun_altitude_degrees.toFixed(2)}° Sun altitude)`,
-      `Moon: ${response.moon.phase_name} in ${response.moon.sign} (${response.moon.phase_angle.toFixed(2)}° phase angle)`,
-    ];
-
-    if (includePlanetaryApplications) {
-      const topLevelAspectText =
-        applyingAspects && applyingAspects.length > 0
-          ? applyingAspects
-              .slice(0, 5)
-              .map(
-                (aspect) =>
-                  `${aspect.from_body} ${aspect.aspect} ${aspect.to_body} (${aspect.orb.toFixed(2)}°)`
-              )
-              .join('\n')
-          : 'No applying aspects found within the configured orb.';
-
-      humanText.push('', 'Applying Aspects:', topLevelAspectText);
-    }
-
-    if (response.ruler_basics) {
-      humanText.push(
-        '',
-        `ASC Ruler: ${response.ruler_basics.asc_sign_ruler.body} in ${response.ruler_basics.asc_sign_ruler.sign} (${response.ruler_basics.asc_sign_ruler.longitude.toFixed(2)}°)`
-      );
-    }
-
-    if (warnings.length > 0) {
-      humanText.push('', `Warnings: ${warnings.join(' ')}`);
-    }
-
-    return {
-      data: response as unknown as Record<string, unknown>,
-      text: humanText.join('\n'),
-    };
+    return this.electionalService.getElectionalContext(input);
   }
 
   /**
@@ -619,218 +388,7 @@ export class AstroService {
    * Find rising-sign windows across a calendar day at a specific location.
    */
   getRisingSignWindows(input: GetRisingSignWindowsInput): ServiceResult<Record<string, unknown>> {
-    const mode = input.mode ?? 'approximate';
-    if (mode !== 'approximate' && mode !== 'exact') {
-      throw new Error(`Invalid mode: ${mode} (must be approximate or exact)`);
-    }
-    if (input.latitude < -90 || input.latitude > 90) {
-      throw new Error(`Invalid latitude: ${input.latitude} (must be between -90 and 90)`);
-    }
-    if (input.longitude < -180 || input.longitude > 180) {
-      throw new Error(`Invalid longitude: ${input.longitude} (must be between -180 and 180)`);
-    }
-
-    const parsed = parseDateOnlyInput(input.date);
-    try {
-      utcToLocal(new Date(), input.timezone);
-    } catch {
-      throw new Error(`Invalid timezone: ${input.timezone}`);
-    }
-
-    const dayStartLocal = {
-      year: parsed.year,
-      month: parsed.month,
-      day: parsed.day,
-      hour: 0,
-      minute: 0,
-      second: 0,
-    };
-    const dayStartUtc = localToUTC(dayStartLocal, input.timezone);
-    const dayEndUtc = addLocalDays(dayStartLocal, input.timezone, 1);
-
-    const getAscSign = (date: Date): { sign: string; longitude: number } => {
-      const jd = this.ephem.dateToJulianDay(date);
-      const houses = this.houseCalc.calculateHouses(jd, input.latitude, input.longitude, 'P');
-      const normalized = ((houses.ascendant % 360) + 360) % 360;
-      return { sign: ZODIAC_SIGNS[Math.floor(normalized / 30)], longitude: normalized };
-    };
-
-    const refineBoundary = (left: Date, right: Date): Date => {
-      const leftSign = getAscSign(left).sign;
-      let lo = left;
-      let hi = right;
-      for (let i = 0; i < 25; i++) {
-        const mid = new Date((lo.getTime() + hi.getTime()) / 2);
-        const midSign = getAscSign(mid).sign;
-        if (midSign === leftSign) {
-          lo = mid;
-        } else {
-          hi = mid;
-        }
-      }
-      return hi;
-    };
-
-    const findSignTransitionsInBucket = (start: Date, end: Date, probeStepMs: number): Date[] => {
-      const boundaries: Date[] = [];
-      let probeCursor = start;
-      let currentSign = getAscSign(probeCursor).sign;
-
-      while (probeCursor < end) {
-        const probeNext = new Date(Math.min(probeCursor.getTime() + probeStepMs, end.getTime()));
-        const nextSign = getAscSign(probeNext).sign;
-        if (nextSign !== currentSign) {
-          boundaries.push(mode === 'exact' ? refineBoundary(probeCursor, probeNext) : probeNext);
-        }
-        probeCursor = probeNext;
-        currentSign = nextSign;
-      }
-
-      return boundaries;
-    };
-
-    const stepMs = mode === 'exact' ? 60 * 60 * 1000 : 2 * 60 * 60 * 1000;
-    const probeStepMs = mode === 'exact' ? 5 * 60 * 1000 : 30 * 60 * 1000;
-    const boundaries: Date[] = [dayStartUtc];
-    let cursor = dayStartUtc;
-    while (cursor < dayEndUtc) {
-      const next = new Date(Math.min(cursor.getTime() + stepMs, dayEndUtc.getTime()));
-      boundaries.push(...findSignTransitionsInBucket(cursor, next, probeStepMs));
-      cursor = next;
-    }
-    boundaries.push(dayEndUtc);
-
-    const windows = boundaries.slice(0, -1).map((start, i) => {
-      const end = boundaries[i + 1];
-      const sample = new Date((start.getTime() + end.getTime()) / 2);
-      const sign = getAscSign(sample).sign;
-      return {
-        sign,
-        start: formatLocalTimestampWithOffset(start, input.timezone),
-        end: formatLocalTimestampWithOffset(end, input.timezone),
-        durationMinutes: Math.round((end.getTime() - start.getTime()) / 60000),
-      };
-    });
-
-    const structuredData = {
-      date: input.date,
-      timezone: input.timezone,
-      location: {
-        latitude: input.latitude,
-        longitude: input.longitude,
-      },
-      mode,
-      windows,
-    };
-
-    const humanText = `Rising Sign Windows (${input.date}, ${input.timezone}, ${mode}):\n\n${windows
-      .map(
-        (window) =>
-          `${window.sign}: ${formatInTimezone(new Date(window.start), input.timezone)} → ${formatInTimezone(new Date(window.end), input.timezone)}`
-      )
-      .join('\n')}`;
-
-    return {
-      data: structuredData,
-      text: humanText,
-    };
-  }
-
-  private getElectionalApplyingAspects(
-    positions: PlanetPosition[],
-    orbDegrees: number
-  ): ElectionalAspect[] {
-    const aspects: ElectionalAspect[] = [];
-
-    for (let i = 0; i < positions.length; i++) {
-      for (let j = i + 1; j < positions.length; j++) {
-        const from = positions[i];
-        const to = positions[j];
-        const currentAngle = this.ephem.calculateAspectAngle(from.longitude, to.longitude);
-
-        for (const aspect of ASPECTS) {
-          const orb = Math.abs(currentAngle - aspect.angle);
-          if (orb > aspect.orb || orb > orbDegrees) {
-            continue;
-          }
-
-          const applying = this.isElectionalAspectApplying(from, to, aspect.angle);
-          if (!applying) {
-            continue;
-          }
-
-          aspects.push({
-            from_body: from.planet,
-            to_body: to.planet,
-            aspect: aspect.name,
-            orb: Number.parseFloat(orb.toFixed(4)),
-            applying: true,
-          });
-        }
-      }
-    }
-
-    return aspects.sort(
-      (a, b) =>
-        a.orb - b.orb ||
-        a.from_body.localeCompare(b.from_body) ||
-        a.to_body.localeCompare(b.to_body) ||
-        a.aspect.localeCompare(b.aspect)
-    );
-  }
-
-  private isElectionalAspectApplying(
-    from: Pick<PlanetPosition, 'longitude' | 'speed'>,
-    to: Pick<PlanetPosition, 'longitude' | 'speed'>,
-    aspectAngle: number
-  ): boolean {
-    const signedSeparation = this.getSignedAngularDifference(from.longitude, to.longitude);
-    const currentSeparation = Math.abs(signedSeparation);
-    if (currentSeparation === aspectAngle) {
-      return false;
-    }
-
-    const separationRate = Math.sign(signedSeparation || 1) * (to.speed - from.speed);
-    if (separationRate === 0) {
-      return false;
-    }
-
-    return currentSeparation < aspectAngle ? separationRate > 0 : separationRate < 0;
-  }
-
-  private getSignedAngularDifference(fromLongitude: number, toLongitude: number): number {
-    const normalized = ((toLongitude - fromLongitude + 540) % 360) - 180;
-    return normalized === -180 ? 180 : normalized;
-  }
-
-  private getElectionalPhaseName(phaseAngle: number): ElectionalPhaseName {
-    if (phaseAngle < 45) return 'new';
-    if (phaseAngle < 90) return 'crescent';
-    if (phaseAngle < 135) return 'first_quarter';
-    if (phaseAngle < 180) return 'gibbous';
-    if (phaseAngle < 225) return 'full';
-    if (phaseAngle < 270) return 'disseminating';
-    if (phaseAngle < 315) return 'last_quarter';
-    return 'balsamic';
-  }
-
-  private getTraditionalSignRuler(sign: string): PlanetName {
-    const signRulers: Record<string, PlanetName> = {
-      Aries: 'Mars',
-      Taurus: 'Venus',
-      Gemini: 'Mercury',
-      Cancer: 'Moon',
-      Leo: 'Sun',
-      Virgo: 'Mercury',
-      Libra: 'Venus',
-      Scorpio: 'Mars',
-      Sagittarius: 'Jupiter',
-      Capricorn: 'Saturn',
-      Aquarius: 'Saturn',
-      Pisces: 'Jupiter',
-    };
-
-    return signRulers[sign] ?? 'Mars';
+    return this.risingSignService.getRisingSignWindows(input);
   }
 
   /**

--- a/src/astro-service/electional-service.ts
+++ b/src/astro-service/electional-service.ts
@@ -1,0 +1,410 @@
+import { Temporal } from '@js-temporal/polyfill';
+import type { EphemerisCalculator } from '../ephemeris.js';
+import type { HouseCalculator } from '../houses.js';
+import { localToUTC } from '../time-utils.js';
+import {
+  ASPECTS,
+  type ElectionalAspect,
+  type ElectionalContextResponse,
+  type ElectionalHouseSystem,
+  type ElectionalPhaseName,
+  PLANETS,
+  type PlanetName,
+  type PlanetPosition,
+  ZODIAC_SIGNS,
+} from '../types.js';
+import { parseDateOnlyInput } from './date-input.js';
+import { normalizeLongitude } from './shared.js';
+
+interface ElectionalContextInput {
+  date: string;
+  time: string;
+  timezone: string;
+  latitude: number;
+  longitude: number;
+  house_system?: ElectionalHouseSystem;
+  include_ruler_basics?: boolean;
+  include_planetary_applications?: boolean;
+  orb_degrees?: number;
+}
+
+interface ElectionalServiceResult {
+  data: Record<string, unknown>;
+  text: string;
+}
+
+interface ElectionalServiceDependencies {
+  ephem: EphemerisCalculator;
+  houseCalc: HouseCalculator;
+}
+
+const ELECTIONAL_CONTEXT_PLANET_IDS = [
+  PLANETS.SUN,
+  PLANETS.MOON,
+  PLANETS.MERCURY,
+  PLANETS.VENUS,
+  PLANETS.MARS,
+  PLANETS.JUPITER,
+  PLANETS.SATURN,
+  PLANETS.URANUS,
+  PLANETS.NEPTUNE,
+  PLANETS.PLUTO,
+];
+
+const ELECTIONAL_CONTEXT_HOUSE_SYSTEMS: ElectionalHouseSystem[] = ['P', 'K', 'W', 'R'];
+
+/**
+ * Internal electional workflow used by `AstroService`.
+ *
+ * @remarks
+ * This module owns validation, deterministic instant resolution, sect/moon
+ * metadata, optional applying-aspect summaries, and readable electional text
+ * while the `AstroService` facade keeps the public contract stable.
+ */
+export class ElectionalService {
+  private readonly ephem: EphemerisCalculator;
+  private readonly houseCalc: HouseCalculator;
+
+  constructor(deps: ElectionalServiceDependencies) {
+    this.ephem = deps.ephem;
+    this.houseCalc = deps.houseCalc;
+  }
+
+  /**
+   * Produce deterministic electional context for a single local instant.
+   */
+  getElectionalContext(input: ElectionalContextInput): ElectionalServiceResult {
+    if (input.latitude < -90 || input.latitude > 90) {
+      throw new Error(`Invalid latitude: ${input.latitude} (must be between -90 and 90)`);
+    }
+    if (input.longitude < -180 || input.longitude > 180) {
+      throw new Error(`Invalid longitude: ${input.longitude} (must be between -180 and 180)`);
+    }
+
+    const houseSystem = input.house_system ?? 'P';
+    if (!ELECTIONAL_CONTEXT_HOUSE_SYSTEMS.includes(houseSystem)) {
+      throw new Error(
+        `Invalid house_system: ${houseSystem} (must be one of ${ELECTIONAL_CONTEXT_HOUSE_SYSTEMS.join(', ')})`
+      );
+    }
+
+    const includeRulerBasics = input.include_ruler_basics ?? false;
+    const includePlanetaryApplications = input.include_planetary_applications ?? true;
+    const orbDegrees = input.orb_degrees ?? 3;
+    if (!Number.isFinite(orbDegrees) || orbDegrees < 0.1 || orbDegrees > 10) {
+      throw new Error(`Invalid orb_degrees: ${orbDegrees} (must be between 0.1 and 10)`);
+    }
+
+    const parsedDate = parseDateOnlyInput(input.date);
+    const parsedTime = parseTimeOnlyInput(input.time);
+    let instantUtc: Date;
+    try {
+      instantUtc = localToUTC(
+        {
+          year: parsedDate.year,
+          month: parsedDate.month,
+          day: parsedDate.day,
+          hour: parsedTime.hour,
+          minute: parsedTime.minute,
+          second: parsedTime.second,
+        },
+        input.timezone,
+        'reject'
+      );
+    } catch (error) {
+      if (error instanceof RangeError) {
+        throw new Error(
+          `Invalid local electional time: ${input.date} ${input.time} in ${input.timezone} is ambiguous or nonexistent due to a DST transition.`
+        );
+      }
+      throw error;
+    }
+
+    const jdUt = this.ephem.dateToJulianDay(instantUtc);
+    const houses = this.houseCalc.calculateHouses(
+      jdUt,
+      input.latitude,
+      input.longitude,
+      houseSystem
+    );
+    const positions = this.ephem.getAllPlanets(jdUt, ELECTIONAL_CONTEXT_PLANET_IDS);
+
+    const sun = positions.find((position) => position.planet === 'Sun');
+    const moon = positions.find((position) => position.planet === 'Moon');
+    if (!sun || !moon) {
+      throw new Error('Ephemeris failed to compute Sun/Moon positions for electional context.');
+    }
+
+    const sunHorizontal = this.ephem.getHorizontalCoordinates(
+      jdUt,
+      sun,
+      input.longitude,
+      input.latitude
+    );
+    const sunAltitudeDegrees = Number.parseFloat(sunHorizontal.trueAltitude.toFixed(2));
+    const isDayChart = sunAltitudeDegrees >= 0;
+
+    const applyingAspects = includePlanetaryApplications
+      ? this.getElectionalApplyingAspects(positions, orbDegrees)
+      : undefined;
+    const moonApplyingAspects = applyingAspects?.filter(
+      (aspect) => aspect.from_body === 'Moon' || aspect.to_body === 'Moon'
+    );
+
+    const phaseAngle = Number.parseFloat(
+      normalizeLongitude(moon.longitude - sun.longitude).toFixed(2)
+    );
+    const warnings: string[] = [];
+    if (Math.abs(sunAltitudeDegrees) < 0.5) {
+      warnings.push('Sun is near the horizon; day/night classification is close to the boundary.');
+    }
+    warnings.push('Moon void-of-course is deferred in this slice and returns null.');
+    if (houses.system !== houseSystem) {
+      warnings.push(
+        `House calculation fell back from ${houseSystem} to ${houses.system} for this location.`
+      );
+    }
+
+    const ascLongitude = normalizeLongitude(houses.ascendant);
+    const ascSign = ZODIAC_SIGNS[Math.floor(ascLongitude / 30)];
+    const response: ElectionalContextResponse = {
+      input: {
+        date: input.date,
+        time: input.time,
+        timezone: input.timezone,
+        latitude: input.latitude,
+        longitude: input.longitude,
+        house_system: houses.system as ElectionalHouseSystem,
+        instant_utc: instantUtc.toISOString(),
+        jd_ut: Number.parseFloat(jdUt.toFixed(8)),
+      },
+      ascendant: {
+        longitude: Number.parseFloat(ascLongitude.toFixed(4)),
+        sign: ascSign,
+        degree_in_sign: Number.parseFloat((ascLongitude % 30).toFixed(4)),
+      },
+      sect: {
+        is_day_chart: isDayChart,
+        sun_altitude_degrees: sunAltitudeDegrees,
+        classification: isDayChart ? 'day' : 'night',
+      },
+      moon: {
+        longitude: Number.parseFloat(moon.longitude.toFixed(4)),
+        sign: moon.sign,
+        phase_angle: phaseAngle,
+        phase_name: this.getElectionalPhaseName(phaseAngle),
+        is_void_of_course: null,
+        ...(moonApplyingAspects !== undefined ? { applying_aspects: moonApplyingAspects } : {}),
+      },
+      meta: {
+        deterministic: true,
+        requires_natal: false,
+        warnings,
+        deferred_features: [
+          'robust_void_of_course',
+          'detailed_ruler_condition',
+          'house_context',
+          'natal_overlays',
+        ],
+      },
+    };
+
+    if (applyingAspects) {
+      response.applying_aspects = applyingAspects;
+    }
+
+    if (includeRulerBasics) {
+      const rulerBody = this.getTraditionalSignRuler(ascSign);
+      const rulerPosition = positions.find((position) => position.planet === rulerBody);
+      if (!rulerPosition) {
+        throw new Error(`Ephemeris failed to compute ASC ruler position for ${rulerBody}.`);
+      }
+      response.ruler_basics = {
+        asc_sign_ruler: {
+          body: rulerBody,
+          longitude: Number.parseFloat(rulerPosition.longitude.toFixed(4)),
+          sign: rulerPosition.sign,
+          speed: Number.parseFloat(rulerPosition.speed.toFixed(6)),
+          is_retrograde: rulerPosition.isRetrograde,
+        },
+      };
+    }
+
+    const humanText = [
+      `Electional context for ${input.date} ${input.time} (${input.timezone})`,
+      '',
+      `Ascendant: ${response.ascendant.degree_in_sign.toFixed(2)}° ${response.ascendant.sign}`,
+      `Sect: ${response.sect.classification} (${response.sect.sun_altitude_degrees.toFixed(2)}° Sun altitude)`,
+      `Moon: ${response.moon.phase_name} in ${response.moon.sign} (${response.moon.phase_angle.toFixed(2)}° phase angle)`,
+    ];
+
+    if (includePlanetaryApplications) {
+      const topLevelAspectText =
+        applyingAspects && applyingAspects.length > 0
+          ? applyingAspects
+              .slice(0, 5)
+              .map(
+                (aspect) =>
+                  `${aspect.from_body} ${aspect.aspect} ${aspect.to_body} (${aspect.orb.toFixed(2)}°)`
+              )
+              .join('\n')
+          : 'No applying aspects found within the configured orb.';
+
+      humanText.push('', 'Applying Aspects:', topLevelAspectText);
+    }
+
+    if (response.ruler_basics) {
+      humanText.push(
+        '',
+        `ASC Ruler: ${response.ruler_basics.asc_sign_ruler.body} in ${response.ruler_basics.asc_sign_ruler.sign} (${response.ruler_basics.asc_sign_ruler.longitude.toFixed(2)}°)`
+      );
+    }
+
+    if (warnings.length > 0) {
+      humanText.push('', `Warnings: ${warnings.join(' ')}`);
+    }
+
+    return {
+      data: response as unknown as Record<string, unknown>,
+      text: humanText.join('\n'),
+    };
+  }
+
+  /**
+   * Return only currently applying aspects inside the requested orb.
+   */
+  private getElectionalApplyingAspects(
+    positions: PlanetPosition[],
+    orbDegrees: number
+  ): ElectionalAspect[] {
+    const aspects: ElectionalAspect[] = [];
+
+    for (let i = 0; i < positions.length; i++) {
+      for (let j = i + 1; j < positions.length; j++) {
+        const from = positions[i];
+        const to = positions[j];
+        const currentAngle = this.ephem.calculateAspectAngle(from.longitude, to.longitude);
+
+        for (const aspect of ASPECTS) {
+          const orb = Math.abs(currentAngle - aspect.angle);
+          if (orb > aspect.orb || orb > orbDegrees) {
+            continue;
+          }
+
+          const applying = this.isElectionalAspectApplying(from, to, aspect.angle);
+          if (!applying) {
+            continue;
+          }
+
+          aspects.push({
+            from_body: from.planet,
+            to_body: to.planet,
+            aspect: aspect.name,
+            orb: Number.parseFloat(orb.toFixed(4)),
+            applying: true,
+          });
+        }
+      }
+    }
+
+    return aspects.sort(
+      (a, b) =>
+        a.orb - b.orb ||
+        a.from_body.localeCompare(b.from_body) ||
+        a.to_body.localeCompare(b.to_body) ||
+        a.aspect.localeCompare(b.aspect)
+    );
+  }
+
+  /**
+   * Determine whether a near-aspect is applying instead of separating.
+   */
+  private isElectionalAspectApplying(
+    from: Pick<PlanetPosition, 'longitude' | 'speed'>,
+    to: Pick<PlanetPosition, 'longitude' | 'speed'>,
+    aspectAngle: number
+  ): boolean {
+    const signedSeparation = this.getSignedAngularDifference(from.longitude, to.longitude);
+    const currentSeparation = Math.abs(signedSeparation);
+    if (currentSeparation === aspectAngle) {
+      return false;
+    }
+
+    const separationRate = Math.sign(signedSeparation || 1) * (to.speed - from.speed);
+    if (separationRate === 0) {
+      return false;
+    }
+
+    return currentSeparation < aspectAngle ? separationRate > 0 : separationRate < 0;
+  }
+
+  /**
+   * Compute the signed shortest angular distance in degrees.
+   */
+  private getSignedAngularDifference(fromLongitude: number, toLongitude: number): number {
+    const normalized = ((toLongitude - fromLongitude + 540) % 360) - 180;
+    return normalized === -180 ? 180 : normalized;
+  }
+
+  /**
+   * Bucket a Sun-Moon phase angle into the service's coarse phase names.
+   */
+  private getElectionalPhaseName(phaseAngle: number): ElectionalPhaseName {
+    if (phaseAngle < 45) return 'new';
+    if (phaseAngle < 90) return 'crescent';
+    if (phaseAngle < 135) return 'first_quarter';
+    if (phaseAngle < 180) return 'gibbous';
+    if (phaseAngle < 225) return 'full';
+    if (phaseAngle < 270) return 'disseminating';
+    if (phaseAngle < 315) return 'last_quarter';
+    return 'balsamic';
+  }
+
+  /**
+   * Return the traditional ruler used for the ascendant sign summary.
+   */
+  private getTraditionalSignRuler(sign: string): PlanetName {
+    const signRulers: Record<string, PlanetName> = {
+      Aries: 'Mars',
+      Taurus: 'Venus',
+      Gemini: 'Mercury',
+      Cancer: 'Moon',
+      Leo: 'Sun',
+      Virgo: 'Mercury',
+      Libra: 'Venus',
+      Scorpio: 'Mars',
+      Sagittarius: 'Jupiter',
+      Capricorn: 'Saturn',
+      Aquarius: 'Saturn',
+      Pisces: 'Jupiter',
+    };
+
+    return signRulers[sign] ?? 'Mars';
+  }
+}
+
+/**
+ * Parse a strict local wall-clock time for electional requests.
+ */
+function parseTimeOnlyInput(timeStr: string): { hour: number; minute: number; second: number } {
+  const match = /^(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(timeStr);
+  if (!match) {
+    throw new Error(`Invalid time format: expected HH:mm[:ss], got "${timeStr}"`);
+  }
+
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  const second = match[3] === undefined ? 0 : Number(match[3]);
+
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59) {
+    throw new Error(`Invalid clock time: ${timeStr}`);
+  }
+
+  try {
+    Temporal.PlainTime.from({ hour, minute, second });
+  } catch {
+    throw new Error(`Invalid clock time: ${timeStr}`);
+  }
+
+  return { hour, minute, second };
+}

--- a/src/astro-service/rising-sign-service.ts
+++ b/src/astro-service/rising-sign-service.ts
@@ -1,0 +1,193 @@
+import type { EphemerisCalculator } from '../ephemeris.js';
+import { formatInTimezone } from '../formatter.js';
+import type { HouseCalculator } from '../houses.js';
+import {
+  addLocalDays,
+  formatLocalTimestampWithOffset,
+  localToUTC,
+  utcToLocal,
+} from '../time-utils.js';
+import { ZODIAC_SIGNS } from '../types.js';
+import { parseDateOnlyInput } from './date-input.js';
+import { normalizeLongitude } from './shared.js';
+
+interface RisingSignWindowsInput {
+  date: string;
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  mode?: 'approximate' | 'exact';
+}
+
+interface RisingSignServiceResult {
+  data: Record<string, unknown>;
+  text: string;
+}
+
+interface RisingSignServiceDependencies {
+  ephem: EphemerisCalculator;
+  houseCalc: HouseCalculator;
+}
+
+/**
+ * Internal rising-sign window scanner used by `AstroService`.
+ *
+ * @remarks
+ * This module owns the local-day scan, optional exact-boundary refinement, and
+ * serialization of sign windows while the public facade keeps the same method
+ * signature and result shape.
+ */
+export class RisingSignService {
+  private readonly ephem: EphemerisCalculator;
+  private readonly houseCalc: HouseCalculator;
+
+  constructor(deps: RisingSignServiceDependencies) {
+    this.ephem = deps.ephem;
+    this.houseCalc = deps.houseCalc;
+  }
+
+  /**
+   * Find rising-sign windows across a local calendar day.
+   */
+  getRisingSignWindows(input: RisingSignWindowsInput): RisingSignServiceResult {
+    const mode = input.mode ?? 'approximate';
+    if (mode !== 'approximate' && mode !== 'exact') {
+      throw new Error(`Invalid mode: ${mode} (must be approximate or exact)`);
+    }
+    if (input.latitude < -90 || input.latitude > 90) {
+      throw new Error(`Invalid latitude: ${input.latitude} (must be between -90 and 90)`);
+    }
+    if (input.longitude < -180 || input.longitude > 180) {
+      throw new Error(`Invalid longitude: ${input.longitude} (must be between -180 and 180)`);
+    }
+
+    const parsed = parseDateOnlyInput(input.date);
+    try {
+      utcToLocal(new Date(), input.timezone);
+    } catch {
+      throw new Error(`Invalid timezone: ${input.timezone}`);
+    }
+
+    const dayStartLocal = {
+      year: parsed.year,
+      month: parsed.month,
+      day: parsed.day,
+      hour: 0,
+      minute: 0,
+      second: 0,
+    };
+    const dayStartUtc = localToUTC(dayStartLocal, input.timezone);
+    const dayEndUtc = addLocalDays(dayStartLocal, input.timezone, 1);
+
+    const stepMs = mode === 'exact' ? 60 * 60 * 1000 : 2 * 60 * 60 * 1000;
+    const probeStepMs = mode === 'exact' ? 5 * 60 * 1000 : 30 * 60 * 1000;
+    const boundaries: Date[] = [dayStartUtc];
+    let cursor = dayStartUtc;
+    while (cursor < dayEndUtc) {
+      const next = new Date(Math.min(cursor.getTime() + stepMs, dayEndUtc.getTime()));
+      boundaries.push(...this.findSignTransitionsInBucket(input, mode, cursor, next, probeStepMs));
+      cursor = next;
+    }
+    boundaries.push(dayEndUtc);
+
+    const windows = boundaries.slice(0, -1).map((start, index) => {
+      const end = boundaries[index + 1];
+      const sample = new Date((start.getTime() + end.getTime()) / 2);
+      const sign = this.getAscSign(input, sample).sign;
+      return {
+        sign,
+        start: formatLocalTimestampWithOffset(start, input.timezone),
+        end: formatLocalTimestampWithOffset(end, input.timezone),
+        durationMinutes: Math.round((end.getTime() - start.getTime()) / 60000),
+      };
+    });
+
+    const structuredData = {
+      date: input.date,
+      timezone: input.timezone,
+      location: {
+        latitude: input.latitude,
+        longitude: input.longitude,
+      },
+      mode,
+      windows,
+    };
+
+    const humanText = `Rising Sign Windows (${input.date}, ${input.timezone}, ${mode}):\n\n${windows
+      .map(
+        (window) =>
+          `${window.sign}: ${formatInTimezone(new Date(window.start), input.timezone)} → ${formatInTimezone(new Date(window.end), input.timezone)}`
+      )
+      .join('\n')}`;
+
+    return {
+      data: structuredData,
+      text: humanText,
+    };
+  }
+
+  /**
+   * Sample the ascendant sign for a specific moment.
+   */
+  private getAscSign(
+    input: Pick<RisingSignWindowsInput, 'latitude' | 'longitude'>,
+    date: Date
+  ): { sign: string; longitude: number } {
+    const jd = this.ephem.dateToJulianDay(date);
+    const houses = this.houseCalc.calculateHouses(jd, input.latitude, input.longitude, 'P');
+    const normalized = normalizeLongitude(houses.ascendant);
+    return { sign: ZODIAC_SIGNS[Math.floor(normalized / 30)], longitude: normalized };
+  }
+
+  /**
+   * Binary-search a sign change down to a stable exact-mode boundary.
+   */
+  private refineBoundary(
+    input: Pick<RisingSignWindowsInput, 'latitude' | 'longitude'>,
+    left: Date,
+    right: Date
+  ): Date {
+    const leftSign = this.getAscSign(input, left).sign;
+    let lo = left;
+    let hi = right;
+    for (let i = 0; i < 25; i++) {
+      const mid = new Date((lo.getTime() + hi.getTime()) / 2);
+      const midSign = this.getAscSign(input, mid).sign;
+      if (midSign === leftSign) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    return hi;
+  }
+
+  /**
+   * Probe a scan bucket and emit every sign transition inside it.
+   */
+  private findSignTransitionsInBucket(
+    input: Pick<RisingSignWindowsInput, 'latitude' | 'longitude'>,
+    mode: 'approximate' | 'exact',
+    start: Date,
+    end: Date,
+    probeStepMs: number
+  ): Date[] {
+    const boundaries: Date[] = [];
+    let probeCursor = start;
+    let currentSign = this.getAscSign(input, probeCursor).sign;
+
+    while (probeCursor < end) {
+      const probeNext = new Date(Math.min(probeCursor.getTime() + probeStepMs, end.getTime()));
+      const nextSign = this.getAscSign(input, probeNext).sign;
+      if (nextSign !== currentSign) {
+        boundaries.push(
+          mode === 'exact' ? this.refineBoundary(input, probeCursor, probeNext) : probeNext
+        );
+      }
+      probeCursor = probeNext;
+      currentSign = nextSign;
+    }
+
+    return boundaries;
+  }
+}

--- a/tests/unit/astro-service-electional-service.test.ts
+++ b/tests/unit/astro-service-electional-service.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ElectionalService } from '../../src/astro-service/electional-service.js';
+import type { PlanetPosition } from '../../src/types.js';
+
+function makePlanet(planet: PlanetPosition['planet'], longitude: number): PlanetPosition {
+  return {
+    planetId: 0,
+    planet,
+    longitude,
+    latitude: 0,
+    distance: 1,
+    speed: 1,
+    sign: 'Aries',
+    degree: longitude % 30,
+    isRetrograde: false,
+  };
+}
+
+function makeElectionalService() {
+  const ephem = {
+    dateToJulianDay: vi.fn((date: Date) => date.getTime() / 86400000 + 2440587.5),
+    calculateAspectAngle: vi.fn((a: number, b: number) => {
+      const diff = Math.abs(a - b);
+      return diff > 180 ? 360 - diff : diff;
+    }),
+    getHorizontalCoordinates: vi.fn(() => ({
+      azimuth: 180,
+      trueAltitude: 25,
+      apparentAltitude: 25,
+    })),
+    getAllPlanets: vi.fn(() => [
+      { ...makePlanet('Sun', 0), sign: 'Aries', speed: 1 },
+      { ...makePlanet('Moon', 58), sign: 'Taurus', speed: 13 },
+      { ...makePlanet('Mercury', 120), sign: 'Leo', speed: 1.2 },
+      { ...makePlanet('Venus', 180), sign: 'Libra', speed: 1.1 },
+      { ...makePlanet('Mars', 240), sign: 'Sagittarius', speed: 0.7 },
+      { ...makePlanet('Jupiter', 300), sign: 'Aquarius', speed: 0.2 },
+      { ...makePlanet('Saturn', 315), sign: 'Aquarius', speed: 0.05, isRetrograde: true },
+      { ...makePlanet('Uranus', 30), sign: 'Taurus', speed: 0.03 },
+      { ...makePlanet('Neptune', 330), sign: 'Pisces', speed: 0.02 },
+      { ...makePlanet('Pluto', 270), sign: 'Capricorn', speed: 0.01 },
+    ]),
+  };
+  const houseCalc = {
+    calculateHouses: vi.fn(() => ({
+      ascendant: 270,
+      mc: 204,
+      cusps: [0, 270, 300, 330, 0, 30, 60, 90, 120, 150, 204, 240, 260],
+      system: 'W' as const,
+    })),
+  };
+
+  const electionalService = new ElectionalService({
+    ephem: ephem as any,
+    houseCalc: houseCalc as any,
+  });
+
+  return { electionalService, ephem, houseCalc };
+}
+
+describe('When using the extracted ElectionalService', () => {
+  it('Given deterministic inputs, then it preserves electional context payloads and optional summaries', () => {
+    const { electionalService } = makeElectionalService();
+
+    const result = electionalService.getElectionalContext({
+      date: '2026-03-28',
+      time: '09:30',
+      timezone: 'America/Los_Angeles',
+      latitude: 37.7749,
+      longitude: -122.4194,
+      include_ruler_basics: true,
+    });
+
+    expect(result.data).toMatchObject({
+      input: {
+        date: '2026-03-28',
+        time: '09:30',
+        timezone: 'America/Los_Angeles',
+        house_system: 'W',
+      },
+      ascendant: {
+        sign: 'Capricorn',
+      },
+      sect: {
+        is_day_chart: true,
+        classification: 'day',
+        sun_altitude_degrees: 25,
+      },
+      moon: {
+        sign: 'Taurus',
+        phase_name: 'crescent',
+        is_void_of_course: null,
+      },
+      ruler_basics: {
+        asc_sign_ruler: {
+          body: 'Saturn',
+          sign: 'Aquarius',
+          is_retrograde: true,
+        },
+      },
+    });
+    expect((result.data as any).applying_aspects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from_body: 'Sun',
+          to_body: 'Moon',
+          aspect: 'sextile',
+          applying: true,
+        }),
+      ])
+    );
+    expect((result.data as any).meta.warnings).toContain(
+      'House calculation fell back from P to W for this location.'
+    );
+    expect(result.text).toContain('Applying Aspects:');
+  });
+
+  it('Given DST-overlap or invalid orb inputs, then it preserves strict validation semantics', () => {
+    const { electionalService } = makeElectionalService();
+
+    expect(() =>
+      electionalService.getElectionalContext({
+        date: '2026-11-01',
+        time: '01:30',
+        timezone: 'America/Los_Angeles',
+        latitude: 37.7749,
+        longitude: -122.4194,
+      })
+    ).toThrow(/ambiguous or nonexistent due to a DST transition/);
+
+    expect(() =>
+      electionalService.getElectionalContext({
+        date: '2026-03-28',
+        time: '09:30',
+        timezone: 'UTC',
+        latitude: 37.7749,
+        longitude: -122.4194,
+        orb_degrees: 11,
+      })
+    ).toThrow(/Invalid orb_degrees/);
+  });
+});

--- a/tests/unit/astro-service-rising-sign-service.test.ts
+++ b/tests/unit/astro-service-rising-sign-service.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RisingSignService } from '../../src/astro-service/rising-sign-service.js';
+
+function makeRisingSignService() {
+  const ephem = {
+    dateToJulianDay: vi.fn((date: Date) => date.getTime() / 86400000 + 2440587.5),
+  };
+  const houseCalc = {
+    calculateHouses: vi.fn(() => ({
+      ascendant: 0,
+      mc: 204,
+      cusps: [0, 270, 300, 330, 0, 30, 60, 90, 120, 150, 204, 240, 260],
+      system: 'P' as const,
+    })),
+  };
+
+  const risingSignService = new RisingSignService({
+    ephem: ephem as any,
+    houseCalc: houseCalc as any,
+  });
+
+  return { risingSignService, ephem, houseCalc };
+}
+
+describe('When using the extracted RisingSignService', () => {
+  it('Given multiple transitions inside one scan bucket, then exact mode emits every sign window', () => {
+    const { risingSignService, houseCalc } = makeRisingSignService();
+    const transitions = [
+      Date.parse('2026-03-28T00:10:00Z'),
+      Date.parse('2026-03-28T00:30:00Z'),
+      Date.parse('2026-03-28T00:50:00Z'),
+    ];
+
+    houseCalc.calculateHouses.mockImplementation((jd: number) => {
+      const date = new Date((jd - 2440587.5) * 86400000);
+      const millis = date.getTime();
+      const signIndex =
+        transitions.filter((transitionMs) => millis >= transitionMs).length % 2 === 0 ? 0 : 1;
+      return {
+        ascendant: signIndex * 30 + 0.1,
+        mc: 204,
+        cusps: [0, 270, 300, 330, 0, 30, 60, 90, 120, 150, 204, 240, 260],
+        system: 'P' as const,
+      };
+    });
+
+    const result = risingSignService.getRisingSignWindows({
+      date: '2026-03-28',
+      latitude: 40.7128,
+      longitude: -74.006,
+      timezone: 'UTC',
+      mode: 'exact',
+    });
+
+    const windows = (result.data as any).windows as Array<{ start: string; sign: string }>;
+    const firstHourWindows = windows.filter((window) => window.start < '2026-03-28T01:00:00+00:00');
+
+    expect(firstHourWindows).toHaveLength(4);
+    expect(firstHourWindows.map((window) => window.sign)).toEqual([
+      'Aries',
+      'Taurus',
+      'Aries',
+      'Taurus',
+    ]);
+    expect(result.text).toContain('Rising Sign Windows');
+  });
+
+  it('Given invalid location or timezone inputs, then it preserves clear validation errors', () => {
+    const { risingSignService } = makeRisingSignService();
+
+    expect(() =>
+      risingSignService.getRisingSignWindows({
+        date: '2026-03-28',
+        latitude: 95,
+        longitude: -74,
+        timezone: 'America/New_York',
+      })
+    ).toThrow(/Invalid latitude/);
+
+    expect(() =>
+      risingSignService.getRisingSignWindows({
+        date: '2026-03-28',
+        latitude: 40,
+        longitude: -190,
+        timezone: 'America/New_York',
+      })
+    ).toThrow(/Invalid longitude/);
+
+    expect(() =>
+      risingSignService.getRisingSignWindows({
+        date: '2026-03-28',
+        latitude: 40,
+        longitude: -74,
+        timezone: 'Nope/Not-A-Timezone',
+      })
+    ).toThrow(/Invalid timezone/);
+  });
+});


### PR DESCRIPTION
## Summary
- extract electional context logic into an internal `ElectionalService`
- extract rising-sign window scanning into an internal `RisingSignService`
- keep `AstroService` as the stable facade and add seam-level tests for both extracted services

## Verification
- `npm run build`
- `npm run lint`
- `npm run quality:gate`