### PR TITLE
refactor(astro-service): extract core domain workflows

### DIFF
--- a/src/astro-service.ts
+++ b/src/astro-service.ts
@@ -1,28 +1,21 @@
 import { writeFile } from 'node:fs/promises';
-import { parseDateOnlyInput } from './astro-service/date-input.js';
+import { ChartOutputService } from './astro-service/chart-output-service.js';
 import { ElectionalService } from './astro-service/electional-service.js';
+import { NatalService } from './astro-service/natal-service.js';
 import { RisingSignService } from './astro-service/rising-sign-service.js';
-import { resolveHouseSystem, resolveReportingTimezone } from './astro-service/shared.js';
+import { resolveReportingTimezone } from './astro-service/shared.js';
+import { SkyService } from './astro-service/sky-service.js';
 import { TransitService } from './astro-service/transit-service.js';
 import { ChartRenderer } from './charts.js';
-import { getDefaultTheme } from './constants.js';
 import { EclipseCalculator } from './eclipses.js';
 import type { McpStartupDefaults } from './entrypoint.js';
 import { EphemerisCalculator } from './ephemeris.js';
-import { formatDateOnly, formatInTimezone } from './formatter.js';
+import { formatInTimezone } from './formatter.js';
 import { HouseCalculator } from './houses.js';
 import { RiseSetCalculator } from './riseset.js';
-import { type Disambiguation, localToUTC, utcToLocal } from './time-utils.js';
+import type { Disambiguation } from './time-utils.js';
 import { TransitCalculator } from './transits.js';
-import {
-  ASTEROIDS,
-  type ElectionalHouseSystem,
-  type HouseSystem,
-  type NatalChart,
-  NODES,
-  PLANETS,
-  ZODIAC_SIGNS,
-} from './types.js';
+import type { ElectionalHouseSystem, HouseSystem, NatalChart } from './types.js';
 
 interface AstroServiceDependencies {
   ephem?: EphemerisCalculator;
@@ -131,6 +124,9 @@ export class AstroService {
   private readonly transitService: TransitService;
   private readonly electionalService: ElectionalService;
   private readonly risingSignService: RisingSignService;
+  private readonly natalService: NatalService;
+  private readonly skyService: SkyService;
+  private readonly chartOutputService: ChartOutputService;
   private readonly now: () => Date;
   private readonly writeFileFn: (
     path: string,
@@ -163,6 +159,25 @@ export class AstroService {
     this.risingSignService = new RisingSignService({
       ephem: this.ephem,
       houseCalc: this.houseCalc,
+    });
+    this.natalService = new NatalService({
+      ephem: this.ephem,
+      houseCalc: this.houseCalc,
+      mcpStartupDefaults: this.mcpStartupDefaults,
+      isInitialized: this.isInitialized.bind(this),
+    });
+    this.skyService = new SkyService({
+      ephem: this.ephem,
+      riseSetCalc: this.riseSetCalc,
+      eclipseCalc: this.eclipseCalc,
+      mcpStartupDefaults: this.mcpStartupDefaults,
+      now: this.now,
+      formatTimestamp: this.formatTimestamp.bind(this),
+    });
+    this.chartOutputService = new ChartOutputService({
+      chartRenderer: this.chartRenderer,
+      now: this.now,
+      writeFile: this.writeFileFn,
     });
   }
 
@@ -199,138 +214,7 @@ export class AstroService {
   setNatalChart(
     input: SetNatalChartInput
   ): ServiceResult<Record<string, unknown>> & { chart: NatalChart } {
-    const requestedHouseSystem = input.house_system ?? null;
-
-    const chart: NatalChart = {
-      name: input.name,
-      birthDate: {
-        year: input.year,
-        month: input.month,
-        day: input.day,
-        hour: input.hour,
-        minute: input.minute,
-      },
-      location: {
-        latitude: input.latitude,
-        longitude: input.longitude,
-        timezone: input.timezone,
-      },
-    };
-
-    const birthTimeDisambiguation = input.birth_time_disambiguation ?? 'reject';
-    const utcDate = localToUTC(chart.birthDate, chart.location.timezone, birthTimeDisambiguation);
-    const utcComponents = utcToLocal(utcDate, 'UTC');
-
-    const jd = this.ephem.dateToJulianDay(utcDate);
-    const planetIds = Object.values(PLANETS);
-    const positions = this.ephem.getAllPlanets(jd, planetIds);
-
-    const isPolar = Math.abs(chart.location.latitude) > 66;
-    let houseSystem: HouseSystem = requestedHouseSystem || 'P';
-    if (isPolar && houseSystem === 'P') {
-      houseSystem = 'W';
-    }
-
-    const houses = this.houseCalc.calculateHouses(
-      jd,
-      chart.location.latitude,
-      chart.location.longitude,
-      houseSystem
-    );
-
-    const storedChart: NatalChart = {
-      ...chart,
-      planets: positions,
-      julianDay: jd,
-      houseSystem: houses.system,
-      requestedHouseSystem: requestedHouseSystem ?? undefined,
-      utcDateTime: utcComponents,
-    };
-
-    const sun = positions.find((p) => p.planet === 'Sun');
-    const moon = positions.find((p) => p.planet === 'Moon');
-    if (!sun || !moon) {
-      throw new Error('Ephemeris failed to compute Sun/Moon positions for natal chart.');
-    }
-
-    const formatDegree = (lon: number): string => {
-      const sign = ZODIAC_SIGNS[Math.floor(lon / 30)];
-      const degree = lon % 30;
-      return `${degree.toFixed(0)}° ${sign}`;
-    };
-
-    const localTimeStr = `${chart.birthDate.month}/${chart.birthDate.day}/${chart.birthDate.year} ${chart.birthDate.hour}:${String(chart.birthDate.minute).padStart(2, '0')}`;
-    const utcTimeStr = `${utcComponents.month}/${utcComponents.day}/${utcComponents.year} ${utcComponents.hour}:${String(utcComponents.minute).padStart(2, '0')} UTC`;
-
-    const systemNames: Record<string, string> = {
-      P: 'Placidus',
-      W: 'Whole Sign',
-      K: 'Koch',
-      E: 'Equal',
-    };
-
-    const latDir = chart.location.latitude >= 0 ? 'N' : 'S';
-    const lonDir = chart.location.longitude >= 0 ? 'E' : 'W';
-    const latAbs = Math.abs(chart.location.latitude);
-    const lonAbs = Math.abs(chart.location.longitude);
-
-    const feedback = [
-      `Natal chart saved for ${chart.name}`,
-      '',
-      'Birth Details:',
-      `- Local Time: ${localTimeStr} (${chart.location.timezone})`,
-      `- UTC Time: ${utcTimeStr}`,
-      `- Location: ${latAbs.toFixed(2)}°${latDir}, ${lonAbs.toFixed(2)}°${lonDir}`,
-      '',
-      'Chart Angles:',
-      `- Sun: ${formatDegree(sun.longitude)}`,
-      `- Moon: ${formatDegree(moon.longitude)}`,
-      `- Ascendant: ${formatDegree(houses.ascendant)}`,
-      `- MC: ${formatDegree(houses.mc)}`,
-      '',
-      `House System: ${systemNames[houses.system] || houses.system}`,
-    ];
-
-    if (isPolar && houses.system !== houseSystem) {
-      feedback.push(
-        '',
-        `Note: Polar latitude detected (${chart.location.latitude.toFixed(1)}°). Requested ${systemNames[houseSystem]}, using ${systemNames[houses.system]} instead.`
-      );
-    } else if (isPolar) {
-      feedback.push(
-        '',
-        `Note: Polar latitude detected (${chart.location.latitude.toFixed(1)}°). Using ${systemNames[houses.system]} house system.`
-      );
-    }
-
-    const structuredData: Record<string, unknown> = {
-      name: chart.name,
-      birthTime: {
-        local: localTimeStr,
-        utc: utcTimeStr,
-        timezone: chart.location.timezone,
-      },
-      location: {
-        latitude: chart.location.latitude,
-        longitude: chart.location.longitude,
-      },
-      julianDay: jd,
-      requestedHouseSystem,
-      resolvedHouseSystem: houses.system,
-      angles: {
-        sun: formatDegree(sun.longitude),
-        moon: formatDegree(moon.longitude),
-        ascendant: formatDegree(houses.ascendant),
-        mc: formatDegree(houses.mc),
-      },
-      isPolar,
-    };
-
-    return {
-      chart: storedChart,
-      data: structuredData,
-      text: feedback.join('\n'),
-    };
+    return this.natalService.setNatalChart(input);
   }
 
   /**
@@ -357,31 +241,7 @@ export class AstroService {
     natalChart: NatalChart,
     input: GetHousesInput = {}
   ): ServiceResult<Record<string, unknown>> {
-    const system = resolveHouseSystem(natalChart, this.mcpStartupDefaults, input.system);
-    if (!natalChart.julianDay) {
-      throw new Error('Natal chart is missing julianDay. Re-run set_natal_chart to fix.');
-    }
-
-    const houses = this.houseCalc.calculateHouses(
-      natalChart.julianDay,
-      natalChart.location.latitude,
-      natalChart.location.longitude,
-      system
-    );
-
-    const humanLines = houses.cusps
-      .slice(1)
-      .map((deg: number, i: number) => {
-        const sign = ZODIAC_SIGNS[Math.floor(deg / 30)];
-        return `House ${i + 1}: ${(deg % 30).toFixed(2)}° ${sign}`;
-      })
-      .join('\n');
-    const humanText = `Houses (${houses.system}):\nAsc: ${houses.ascendant.toFixed(2)}° | MC: ${houses.mc.toFixed(2)}°\n\n${humanLines}`;
-
-    return {
-      data: houses as unknown as Record<string, unknown>,
-      text: humanText,
-    };
+    return this.natalService.getHouses(natalChart, input);
   }
 
   /**
@@ -395,180 +255,35 @@ export class AstroService {
    * Return the currently retrograde planets for the requested reporting timezone.
    */
   getRetrogradePlanets(timezone?: string): ServiceResult<Record<string, unknown>> {
-    const resolvedTimezone = this.resolveReportingTimezone(timezone);
-    const now = this.now();
-    const jd = this.ephem.dateToJulianDay(now);
-    const allPlanetIds = Object.values(PLANETS);
-    const positions = this.ephem.getAllPlanets(jd, allPlanetIds);
-    const retrograde = positions.filter((p) => p.isRetrograde);
-
-    const localNow = utcToLocal(now, resolvedTimezone);
-    const dateLabel = `${localNow.year}-${String(localNow.month).padStart(2, '0')}-${String(localNow.day).padStart(2, '0')}`;
-
-    const structuredData = {
-      date: dateLabel,
-      timezone: resolvedTimezone,
-      planets: retrograde,
-    };
-
-    const humanText =
-      retrograde.length === 0
-        ? 'No planets are currently retrograde.'
-        : `Retrograde Planets:\n\n${retrograde.map((p) => `${p.planet}: ${p.degree.toFixed(2)}° ${p.sign}`).join('\n')}`;
-
-    return { data: structuredData, text: humanText };
+    return this.skyService.getRetrogradePlanets(timezone);
   }
 
   /**
    * Return the next rise and set events after the local day anchor for the chart location.
    */
   async getRiseSetTimes(natalChart: NatalChart): Promise<ServiceResult<Record<string, unknown>>> {
-    const timezone = natalChart.location.timezone;
-    const reportingTimezone = this.mcpStartupDefaults.preferredTimezone || timezone;
-    const now = this.now();
-    const localNow = utcToLocal(now, timezone);
-    const localMidnight = {
-      year: localNow.year,
-      month: localNow.month,
-      day: localNow.day,
-      hour: 0,
-      minute: 0,
-      second: 0,
-    };
-    const midnightUTC = localToUTC(localMidnight, timezone);
-
-    const dateLabel = `${localNow.year}-${String(localNow.month).padStart(2, '0')}-${String(localNow.day).padStart(2, '0')}`;
-
-    const results = await this.riseSetCalc.getAllRiseSet(
-      midnightUTC,
-      natalChart.location.latitude,
-      natalChart.location.longitude
-    );
-
-    const structuredData = {
-      date: dateLabel,
-      timezone,
-      times: results.map((r) => ({
-        planet: r.planet,
-        rise: r.rise?.toISOString() ?? null,
-        set: r.set?.toISOString() ?? null,
-      })),
-    };
-
-    const humanText = `Rise/Set Times:\n\n${results
-      .map((r) => {
-        const rise = r.rise ? this.formatTimestamp(r.rise, reportingTimezone) : 'none';
-        const set = r.set ? this.formatTimestamp(r.set, reportingTimezone) : 'none';
-        return `${r.planet}: Rise ${rise}, Set ${set}`;
-      })
-      .join('\n')}`;
-
-    return {
-      data: structuredData,
-      text: humanText,
-    };
+    return this.skyService.getRiseSetTimes(natalChart);
   }
 
   /**
    * Return current asteroid and node positions for the requested reporting timezone.
    */
   getAsteroidPositions(timezone?: string): ServiceResult<Record<string, unknown>> {
-    const resolvedTimezone = this.resolveReportingTimezone(timezone);
-    const now = this.now();
-    const jd = this.ephem.dateToJulianDay(now);
-    const asteroidIds = [...ASTEROIDS, ...NODES];
-    const positions = this.ephem.getAllPlanets(jd, asteroidIds);
-
-    const localNow = utcToLocal(now, resolvedTimezone);
-    const dateLabel = `${localNow.year}-${String(localNow.month).padStart(2, '0')}-${String(localNow.day).padStart(2, '0')}`;
-
-    const structuredData = {
-      date: dateLabel,
-      timezone: resolvedTimezone,
-      positions,
-    };
-
-    const humanText = `Asteroid & Node Positions:\n\n${positions
-      .map((p) => {
-        const rx = p.isRetrograde ? ' Rx' : '';
-        return `${p.planet}: ${p.degree.toFixed(2)}° ${p.sign}${rx}`;
-      })
-      .join('\n')}`;
-
-    return {
-      data: structuredData,
-      text: humanText,
-    };
+    return this.skyService.getAsteroidPositions(timezone);
   }
 
   /**
    * Look up the next solar and lunar eclipses after the current instant.
    */
   getNextEclipses(timezone?: string): ServiceResult<Record<string, unknown>> {
-    const resolvedTimezone = this.resolveReportingTimezone(timezone);
-    const now = this.now();
-    const jd = this.ephem.dateToJulianDay(now);
-
-    const solarEclipse = this.eclipseCalc.findNextSolarEclipse(jd);
-    const lunarEclipse = this.eclipseCalc.findNextLunarEclipse(jd);
-
-    const eclipses: Array<{ type: string; eclipseType: string; maxTime: string }> = [];
-    const humanLines: string[] = [];
-
-    if (solarEclipse) {
-      eclipses.push({
-        type: solarEclipse.type,
-        eclipseType: solarEclipse.eclipseType,
-        maxTime: solarEclipse.maxTime.toISOString(),
-      });
-      humanLines.push(
-        `Next Solar Eclipse: ${this.formatTimestamp(solarEclipse.maxTime, resolvedTimezone)} (${solarEclipse.eclipseType})`
-      );
-    }
-
-    if (lunarEclipse) {
-      eclipses.push({
-        type: lunarEclipse.type,
-        eclipseType: lunarEclipse.eclipseType,
-        maxTime: lunarEclipse.maxTime.toISOString(),
-      });
-      humanLines.push(
-        `Next Lunar Eclipse: ${this.formatTimestamp(lunarEclipse.maxTime, resolvedTimezone)} (${lunarEclipse.eclipseType})`
-      );
-    }
-
-    const structuredData = { timezone: resolvedTimezone, eclipses };
-    const humanText =
-      eclipses.length === 0
-        ? 'No eclipses found in the near future.'
-        : `Upcoming Eclipses:\n\n${humanLines.join('\n')}`;
-
-    return { data: structuredData, text: humanText };
+    return this.skyService.getNextEclipses(timezone);
   }
 
   /**
    * Summarize process-local server state and configured startup defaults.
    */
   getServerStatus(natalChart: NatalChart | null): ServiceResult<Record<string, unknown>> {
-    const statusData = {
-      serverVersion: '1.0.0',
-      hasNatalChart: natalChart !== null,
-      natalChartName: natalChart?.name ?? null,
-      natalChartTimezone: natalChart?.location.timezone ?? null,
-      startupDefaults: {
-        preferredTimezone: this.mcpStartupDefaults.preferredTimezone ?? null,
-        preferredHouseStyle: this.mcpStartupDefaults.preferredHouseStyle ?? null,
-        weekdayLabels: this.mcpStartupDefaults.weekdayLabels ?? null,
-      },
-      ephemerisInitialized: this.isInitialized(),
-      stateModel: 'stateful-per-process',
-    };
-
-    const humanText = natalChart
-      ? `Server ready. Natal chart loaded: ${natalChart.name} (${natalChart.location.timezone})`
-      : 'Server ready. No natal chart loaded — call set_natal_chart first.';
-
-    return { data: statusData, text: humanText };
+    return this.natalService.getServerStatus(natalChart);
   }
 
   /**
@@ -578,42 +293,7 @@ export class AstroService {
     natalChart: NatalChart,
     input: GenerateChartInput = {}
   ): Promise<ChartServiceResult> {
-    const theme = input.theme || getDefaultTheme(natalChart.location.timezone);
-    const format = input.format || 'svg';
-    const outputPath = input.output_path;
-    const chart = await this.chartRenderer.generateNatalChart(natalChart, theme, format);
-
-    if (outputPath) {
-      if (format === 'svg') {
-        await this.writeFileFn(outputPath, chart as string, 'utf-8');
-      } else {
-        await this.writeFileFn(outputPath, chart as Buffer);
-      }
-      return {
-        format,
-        outputPath,
-        text: `Natal Chart for ${natalChart.name} saved to: ${outputPath}`,
-      };
-    }
-
-    if (format === 'svg') {
-      return {
-        format,
-        text: `Natal Chart for ${natalChart.name}:`,
-        svg: chart as string,
-      };
-    }
-
-    const base64 = (chart as Buffer).toString('base64');
-    const mimeType = format === 'png' ? 'image/png' : 'image/webp';
-    return {
-      format,
-      text: `Natal Chart for ${natalChart.name} (${theme} theme, ${format.toUpperCase()} format):`,
-      image: {
-        data: base64,
-        mimeType,
-      },
-    };
+    return this.chartOutputService.generateNatalChart(natalChart, input);
   }
 
   /**
@@ -623,60 +303,6 @@ export class AstroService {
     natalChart: NatalChart,
     input: GenerateTransitChartInput = {}
   ): Promise<ChartServiceResult> {
-    const dateStr = input.date;
-    const theme = input.theme ?? getDefaultTheme(natalChart.location.timezone);
-    const format = input.format ?? 'svg';
-
-    let targetDate: Date;
-    if (dateStr) {
-      const parsed = parseDateOnlyInput(dateStr);
-      targetDate = localToUTC(parsed, natalChart.location.timezone);
-    } else {
-      const now = this.now();
-      const localNow = utcToLocal(now, natalChart.location.timezone);
-      const localNoon = { ...localNow, hour: 12, minute: 0, second: 0 };
-      targetDate = localToUTC(localNoon, natalChart.location.timezone);
-    }
-
-    const outputPath = input.output_path;
-    const chart = await this.chartRenderer.generateTransitChart(
-      natalChart,
-      targetDate,
-      theme,
-      format
-    );
-    const dateLabel = formatDateOnly(targetDate, natalChart.location.timezone);
-
-    if (outputPath) {
-      if (format === 'svg') {
-        await this.writeFileFn(outputPath, chart as string, 'utf-8');
-      } else {
-        await this.writeFileFn(outputPath, chart as Buffer);
-      }
-      return {
-        format,
-        outputPath,
-        text: `Transit Chart for ${natalChart.name} (${dateLabel}) saved to ${outputPath}`,
-      };
-    }
-
-    if (format === 'svg') {
-      return {
-        format,
-        text: `Transit Chart for ${natalChart.name} (${dateLabel})`,
-        svg: chart as string,
-      };
-    }
-
-    const base64 = (chart as Buffer).toString('base64');
-    const mimeType = format === 'png' ? 'image/png' : 'image/webp';
-    return {
-      format,
-      text: `Transit Chart for ${natalChart.name} (${dateLabel}, ${theme} theme, ${format.toUpperCase()} format):`,
-      image: {
-        data: base64,
-        mimeType,
-      },
-    };
+    return this.chartOutputService.generateTransitChart(natalChart, input);
   }
 }

--- a/src/astro-service/chart-output-service.ts
+++ b/src/astro-service/chart-output-service.ts
@@ -1,0 +1,164 @@
+import type { ChartRenderer } from '../charts.js';
+import { getDefaultTheme } from '../constants.js';
+import { formatDateOnly } from '../formatter.js';
+import { localToUTC, utcToLocal } from '../time-utils.js';
+import type { NatalChart } from '../types.js';
+import { parseDateOnlyInput } from './date-input.js';
+
+interface GenerateChartInput {
+  theme?: 'light' | 'dark';
+  format?: 'svg' | 'png' | 'webp';
+  output_path?: string;
+}
+
+interface GenerateTransitChartInput extends GenerateChartInput {
+  date?: string;
+}
+
+interface ChartServiceResult {
+  format: 'svg' | 'png' | 'webp';
+  outputPath?: string;
+  text: string;
+  svg?: string;
+  image?: {
+    data: string;
+    mimeType: string;
+  };
+}
+
+interface ChartOutputServiceDependencies {
+  chartRenderer: ChartRenderer;
+  now: () => Date;
+  writeFile: (path: string, data: string | Buffer, encoding?: BufferEncoding) => Promise<void>;
+}
+
+/**
+ * Internal chart rendering/output workflow used by `AstroService`.
+ *
+ * @remarks
+ * This module owns theme defaults, target-date resolution, and inline-vs-file
+ * output serialization for natal and transit chart rendering.
+ */
+export class ChartOutputService {
+  private readonly chartRenderer: ChartRenderer;
+  private readonly now: () => Date;
+  private readonly writeFile: (
+    path: string,
+    data: string | Buffer,
+    encoding?: BufferEncoding
+  ) => Promise<void>;
+
+  constructor(deps: ChartOutputServiceDependencies) {
+    this.chartRenderer = deps.chartRenderer;
+    this.now = deps.now;
+    this.writeFile = deps.writeFile;
+  }
+
+  /**
+   * Generate a natal chart image or SVG for the current chart.
+   */
+  async generateNatalChart(
+    natalChart: NatalChart,
+    input: GenerateChartInput = {}
+  ): Promise<ChartServiceResult> {
+    const theme = input.theme || getDefaultTheme(natalChart.location.timezone);
+    const format = input.format || 'svg';
+    const outputPath = input.output_path;
+    const chart = await this.chartRenderer.generateNatalChart(natalChart, theme, format);
+
+    if (outputPath) {
+      if (format === 'svg') {
+        await this.writeFile(outputPath, chart as string, 'utf-8');
+      } else {
+        await this.writeFile(outputPath, chart as Buffer);
+      }
+      return {
+        format,
+        outputPath,
+        text: `Natal Chart for ${natalChart.name} saved to: ${outputPath}`,
+      };
+    }
+
+    if (format === 'svg') {
+      return {
+        format,
+        text: `Natal Chart for ${natalChart.name}:`,
+        svg: chart as string,
+      };
+    }
+
+    return {
+      format,
+      text: `Natal Chart for ${natalChart.name} (${theme} theme, ${format.toUpperCase()} format):`,
+      image: {
+        data: (chart as Buffer).toString('base64'),
+        mimeType: format === 'png' ? 'image/png' : 'image/webp',
+      },
+    };
+  }
+
+  /**
+   * Generate a transit chart image or SVG for a target date.
+   */
+  async generateTransitChart(
+    natalChart: NatalChart,
+    input: GenerateTransitChartInput = {}
+  ): Promise<ChartServiceResult> {
+    const theme = input.theme ?? getDefaultTheme(natalChart.location.timezone);
+    const format = input.format ?? 'svg';
+    const targetDate = this.resolveTransitTargetDate(natalChart, input.date);
+    const outputPath = input.output_path;
+    const chart = await this.chartRenderer.generateTransitChart(
+      natalChart,
+      targetDate,
+      theme,
+      format
+    );
+    const dateLabel = formatDateOnly(targetDate, natalChart.location.timezone);
+
+    if (outputPath) {
+      if (format === 'svg') {
+        await this.writeFile(outputPath, chart as string, 'utf-8');
+      } else {
+        await this.writeFile(outputPath, chart as Buffer);
+      }
+      return {
+        format,
+        outputPath,
+        text: `Transit Chart for ${natalChart.name} (${dateLabel}) saved to ${outputPath}`,
+      };
+    }
+
+    if (format === 'svg') {
+      return {
+        format,
+        text: `Transit Chart for ${natalChart.name} (${dateLabel})`,
+        svg: chart as string,
+      };
+    }
+
+    return {
+      format,
+      text: `Transit Chart for ${natalChart.name} (${dateLabel}, ${theme} theme, ${format.toUpperCase()} format):`,
+      image: {
+        data: (chart as Buffer).toString('base64'),
+        mimeType: format === 'png' ? 'image/png' : 'image/webp',
+      },
+    };
+  }
+
+  /**
+   * Resolve the local-noon transit anchor when the caller omits a date.
+   */
+  private resolveTransitTargetDate(natalChart: NatalChart, dateStr?: string): Date {
+    if (dateStr) {
+      const parsed = parseDateOnlyInput(dateStr);
+      return localToUTC(parsed, natalChart.location.timezone);
+    }
+
+    const now = this.now();
+    const localNow = utcToLocal(now, natalChart.location.timezone);
+    const localNoon = { ...localNow, hour: 12, minute: 0, second: 0 };
+    return localToUTC(localNoon, natalChart.location.timezone);
+  }
+}

--- a/src/astro-service/natal-service.ts
+++ b/src/astro-service/natal-service.ts
@@ -1,0 +1,257 @@
+import type { McpStartupDefaults } from '../entrypoint.js';
+import type { EphemerisCalculator } from '../ephemeris.js';
+import type { HouseCalculator } from '../houses.js';
+import { type Disambiguation, localToUTC, utcToLocal } from '../time-utils.js';
+import { type HouseSystem, type NatalChart, PLANETS, ZODIAC_SIGNS } from '../types.js';
+import { resolveHouseSystem } from './shared.js';
+
+interface SetNatalChartInput {
+  name: string;
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  house_system?: HouseSystem;
+  birth_time_disambiguation?: Disambiguation;
+}
+
+interface GetHousesInput {
+  system?: string;
+}
+
+interface ServiceResult<T> {
+  data: T;
+  text: string;
+}
+
+interface NatalServiceDependencies {
+  ephem: EphemerisCalculator;
+  houseCalc: HouseCalculator;
+  mcpStartupDefaults: Readonly<McpStartupDefaults>;
+  isInitialized: () => boolean;
+}
+
+/**
+ * Internal natal/chart-state workflow used by `AstroService`.
+ *
+ * @remarks
+ * This module owns natal chart initialization, house resolution, and basic
+ * server-status serialization while the public `AstroService` facade preserves
+ * the existing contract for MCP and CLI callers.
+ */
+export class NatalService {
+  private readonly ephem: EphemerisCalculator;
+  private readonly houseCalc: HouseCalculator;
+  private readonly mcpStartupDefaults: Readonly<McpStartupDefaults>;
+  private readonly isInitialized: () => boolean;
+
+  constructor(deps: NatalServiceDependencies) {
+    this.ephem = deps.ephem;
+    this.houseCalc = deps.houseCalc;
+    this.mcpStartupDefaults = deps.mcpStartupDefaults;
+    this.isInitialized = deps.isInitialized;
+  }
+
+  /**
+   * Build and cache the shared natal chart payload used by later workflows.
+   */
+  setNatalChart(
+    input: SetNatalChartInput
+  ): ServiceResult<Record<string, unknown>> & { chart: NatalChart } {
+    const requestedHouseSystem = input.house_system ?? null;
+
+    const chart: NatalChart = {
+      name: input.name,
+      birthDate: {
+        year: input.year,
+        month: input.month,
+        day: input.day,
+        hour: input.hour,
+        minute: input.minute,
+      },
+      location: {
+        latitude: input.latitude,
+        longitude: input.longitude,
+        timezone: input.timezone,
+      },
+    };
+
+    const birthTimeDisambiguation = input.birth_time_disambiguation ?? 'reject';
+    const utcDate = localToUTC(chart.birthDate, chart.location.timezone, birthTimeDisambiguation);
+    const utcComponents = utcToLocal(utcDate, 'UTC');
+
+    const jd = this.ephem.dateToJulianDay(utcDate);
+    const planetIds = Object.values(PLANETS);
+    const positions = this.ephem.getAllPlanets(jd, planetIds);
+
+    const isPolar = Math.abs(chart.location.latitude) > 66;
+    let houseSystem: HouseSystem = requestedHouseSystem || 'P';
+    if (isPolar && houseSystem === 'P') {
+      houseSystem = 'W';
+    }
+
+    const houses = this.houseCalc.calculateHouses(
+      jd,
+      chart.location.latitude,
+      chart.location.longitude,
+      houseSystem
+    );
+
+    const storedChart: NatalChart = {
+      ...chart,
+      planets: positions,
+      julianDay: jd,
+      houseSystem: houses.system,
+      requestedHouseSystem: requestedHouseSystem ?? undefined,
+      utcDateTime: utcComponents,
+    };
+
+    const sun = positions.find((position) => position.planet === 'Sun');
+    const moon = positions.find((position) => position.planet === 'Moon');
+    if (!sun || !moon) {
+      throw new Error('Ephemeris failed to compute Sun/Moon positions for natal chart.');
+    }
+
+    const formatDegree = (longitude: number): string => {
+      const sign = ZODIAC_SIGNS[Math.floor(longitude / 30)];
+      const degree = longitude % 30;
+      return `${degree.toFixed(0)}° ${sign}`;
+    };
+
+    const localTimeStr = `${chart.birthDate.month}/${chart.birthDate.day}/${chart.birthDate.year} ${chart.birthDate.hour}:${String(chart.birthDate.minute).padStart(2, '0')}`;
+    const utcTimeStr = `${utcComponents.month}/${utcComponents.day}/${utcComponents.year} ${utcComponents.hour}:${String(utcComponents.minute).padStart(2, '0')} UTC`;
+
+    const systemNames: Record<string, string> = {
+      P: 'Placidus',
+      W: 'Whole Sign',
+      K: 'Koch',
+      E: 'Equal',
+    };
+
+    const latDir = chart.location.latitude >= 0 ? 'N' : 'S';
+    const lonDir = chart.location.longitude >= 0 ? 'E' : 'W';
+    const latAbs = Math.abs(chart.location.latitude);
+    const lonAbs = Math.abs(chart.location.longitude);
+
+    const feedback = [
+      `Natal chart saved for ${chart.name}`,
+      '',
+      'Birth Details:',
+      `- Local Time: ${localTimeStr} (${chart.location.timezone})`,
+      `- UTC Time: ${utcTimeStr}`,
+      `- Location: ${latAbs.toFixed(2)}°${latDir}, ${lonAbs.toFixed(2)}°${lonDir}`,
+      '',
+      'Chart Angles:',
+      `- Sun: ${formatDegree(sun.longitude)}`,
+      `- Moon: ${formatDegree(moon.longitude)}`,
+      `- Ascendant: ${formatDegree(houses.ascendant)}`,
+      `- MC: ${formatDegree(houses.mc)}`,
+      '',
+      `House System: ${systemNames[houses.system] || houses.system}`,
+    ];
+
+    if (isPolar && houses.system !== houseSystem) {
+      feedback.push(
+        '',
+        `Note: Polar latitude detected (${chart.location.latitude.toFixed(1)}°). Requested ${systemNames[houseSystem]}, using ${systemNames[houses.system]} instead.`
+      );
+    } else if (isPolar) {
+      feedback.push(
+        '',
+        `Note: Polar latitude detected (${chart.location.latitude.toFixed(1)}°). Using ${systemNames[houses.system]} house system.`
+      );
+    }
+
+    const structuredData: Record<string, unknown> = {
+      name: chart.name,
+      birthTime: {
+        local: localTimeStr,
+        utc: utcTimeStr,
+        timezone: chart.location.timezone,
+      },
+      location: {
+        latitude: chart.location.latitude,
+        longitude: chart.location.longitude,
+      },
+      julianDay: jd,
+      requestedHouseSystem,
+      resolvedHouseSystem: houses.system,
+      angles: {
+        sun: formatDegree(sun.longitude),
+        moon: formatDegree(moon.longitude),
+        ascendant: formatDegree(houses.ascendant),
+        mc: formatDegree(houses.mc),
+      },
+      isPolar,
+    };
+
+    return {
+      chart: storedChart,
+      data: structuredData,
+      text: feedback.join('\n'),
+    };
+  }
+
+  /**
+   * Calculate house cusps and angles for a natal chart.
+   */
+  getHouses(
+    natalChart: NatalChart,
+    input: GetHousesInput = {}
+  ): ServiceResult<Record<string, unknown>> {
+    const system = resolveHouseSystem(natalChart, this.mcpStartupDefaults, input.system);
+    if (!natalChart.julianDay) {
+      throw new Error('Natal chart is missing julianDay. Re-run set_natal_chart to fix.');
+    }
+
+    const houses = this.houseCalc.calculateHouses(
+      natalChart.julianDay,
+      natalChart.location.latitude,
+      natalChart.location.longitude,
+      system
+    );
+
+    const humanLines = houses.cusps
+      .slice(1)
+      .map((degree, index) => {
+        const sign = ZODIAC_SIGNS[Math.floor(degree / 30)];
+        return `House ${index + 1}: ${(degree % 30).toFixed(2)}° ${sign}`;
+      })
+      .join('\n');
+    const humanText = `Houses (${houses.system}):\nAsc: ${houses.ascendant.toFixed(2)}° | MC: ${houses.mc.toFixed(2)}°\n\n${humanLines}`;
+
+    return {
+      data: houses as unknown as Record<string, unknown>,
+      text: humanText,
+    };
+  }
+
+  /**
+   * Summarize process-local server state and configured startup defaults.
+   */
+  getServerStatus(natalChart: NatalChart | null): ServiceResult<Record<string, unknown>> {
+    const statusData = {
+      serverVersion: '1.0.0',
+      hasNatalChart: natalChart !== null,
+      natalChartName: natalChart?.name ?? null,
+      natalChartTimezone: natalChart?.location.timezone ?? null,
+      startupDefaults: {
+        preferredTimezone: this.mcpStartupDefaults.preferredTimezone ?? null,
+        preferredHouseStyle: this.mcpStartupDefaults.preferredHouseStyle ?? null,
+        weekdayLabels: this.mcpStartupDefaults.weekdayLabels ?? null,
+      },
+      ephemerisInitialized: this.isInitialized(),
+      stateModel: 'stateful-per-process',
+    };
+
+    const humanText = natalChart
+      ? `Server ready. Natal chart loaded: ${natalChart.name} (${natalChart.location.timezone})`
+      : 'Server ready. No natal chart loaded — call set_natal_chart first.';
+
+    return { data: statusData, text: humanText };
+  }
+}

--- a/src/astro-service/sky-service.ts
+++ b/src/astro-service/sky-service.ts
@@ -1,0 +1,195 @@
+import type { EclipseCalculator } from '../eclipses.js';
+import type { McpStartupDefaults } from '../entrypoint.js';
+import type { EphemerisCalculator } from '../ephemeris.js';
+import type { RiseSetCalculator } from '../riseset.js';
+import { localToUTC, utcToLocal } from '../time-utils.js';
+import { ASTEROIDS, type NatalChart, NODES, PLANETS } from '../types.js';
+import { resolveReportingTimezone } from './shared.js';
+
+interface ServiceResult<T> {
+  data: T;
+  text: string;
+}
+
+interface SkyServiceDependencies {
+  ephem: EphemerisCalculator;
+  riseSetCalc: RiseSetCalculator;
+  eclipseCalc: EclipseCalculator;
+  mcpStartupDefaults: Readonly<McpStartupDefaults>;
+  now: () => Date;
+  formatTimestamp: (date: Date, timezone: string) => string;
+}
+
+/**
+ * Internal current-sky and runtime lookup workflow used by `AstroService`.
+ *
+ * @remarks
+ * This module owns read-only runtime lookups that depend on "now", including
+ * retrogrades, asteroid/node snapshots, rise/set tables, and eclipse queries.
+ */
+export class SkyService {
+  private readonly ephem: EphemerisCalculator;
+  private readonly riseSetCalc: RiseSetCalculator;
+  private readonly eclipseCalc: EclipseCalculator;
+  private readonly mcpStartupDefaults: Readonly<McpStartupDefaults>;
+  private readonly now: () => Date;
+  private readonly formatTimestamp: (date: Date, timezone: string) => string;
+
+  constructor(deps: SkyServiceDependencies) {
+    this.ephem = deps.ephem;
+    this.riseSetCalc = deps.riseSetCalc;
+    this.eclipseCalc = deps.eclipseCalc;
+    this.mcpStartupDefaults = deps.mcpStartupDefaults;
+    this.now = deps.now;
+    this.formatTimestamp = deps.formatTimestamp;
+  }
+
+  /**
+   * Return the currently retrograde planets for the requested reporting timezone.
+   */
+  getRetrogradePlanets(timezone?: string): ServiceResult<Record<string, unknown>> {
+    const resolvedTimezone = resolveReportingTimezone(this.mcpStartupDefaults, timezone);
+    const now = this.now();
+    const jd = this.ephem.dateToJulianDay(now);
+    const positions = this.ephem.getAllPlanets(jd, Object.values(PLANETS));
+    const retrograde = positions.filter((position) => position.isRetrograde);
+
+    const structuredData = {
+      date: this.getDateLabel(now, resolvedTimezone),
+      timezone: resolvedTimezone,
+      planets: retrograde,
+    };
+
+    const humanText =
+      retrograde.length === 0
+        ? 'No planets are currently retrograde.'
+        : `Retrograde Planets:\n\n${retrograde.map((position) => `${position.planet}: ${position.degree.toFixed(2)}° ${position.sign}`).join('\n')}`;
+
+    return { data: structuredData, text: humanText };
+  }
+
+  /**
+   * Return the next rise and set events after the local day anchor for the chart location.
+   */
+  async getRiseSetTimes(natalChart: NatalChart): Promise<ServiceResult<Record<string, unknown>>> {
+    const timezone = natalChart.location.timezone;
+    const reportingTimezone = this.mcpStartupDefaults.preferredTimezone || timezone;
+    const now = this.now();
+    const localNow = utcToLocal(now, timezone);
+    const localMidnight = {
+      year: localNow.year,
+      month: localNow.month,
+      day: localNow.day,
+      hour: 0,
+      minute: 0,
+      second: 0,
+    };
+    const midnightUTC = localToUTC(localMidnight, timezone);
+
+    const results = await this.riseSetCalc.getAllRiseSet(
+      midnightUTC,
+      natalChart.location.latitude,
+      natalChart.location.longitude
+    );
+
+    const structuredData = {
+      date: this.getDateLabel(now, timezone),
+      timezone,
+      times: results.map((result) => ({
+        planet: result.planet,
+        rise: result.rise?.toISOString() ?? null,
+        set: result.set?.toISOString() ?? null,
+      })),
+    };
+
+    const humanText = `Rise/Set Times:\n\n${results
+      .map((result) => {
+        const rise = result.rise ? this.formatTimestamp(result.rise, reportingTimezone) : 'none';
+        const set = result.set ? this.formatTimestamp(result.set, reportingTimezone) : 'none';
+        return `${result.planet}: Rise ${rise}, Set ${set}`;
+      })
+      .join('\n')}`;
+
+    return {
+      data: structuredData,
+      text: humanText,
+    };
+  }
+
+  /**
+   * Return current asteroid and node positions for the requested reporting timezone.
+   */
+  getAsteroidPositions(timezone?: string): ServiceResult<Record<string, unknown>> {
+    const resolvedTimezone = resolveReportingTimezone(this.mcpStartupDefaults, timezone);
+    const now = this.now();
+    const jd = this.ephem.dateToJulianDay(now);
+    const positions = this.ephem.getAllPlanets(jd, [...ASTEROIDS, ...NODES]);
+
+    const structuredData = {
+      date: this.getDateLabel(now, resolvedTimezone),
+      timezone: resolvedTimezone,
+      positions,
+    };
+
+    const humanText = `Asteroid & Node Positions:\n\n${positions
+      .map((position) => {
+        const retrogradeLabel = position.isRetrograde ? ' Rx' : '';
+        return `${position.planet}: ${position.degree.toFixed(2)}° ${position.sign}${retrogradeLabel}`;
+      })
+      .join('\n')}`;
+
+    return {
+      data: structuredData,
+      text: humanText,
+    };
+  }
+
+  /**
+   * Look up the next solar and lunar eclipses after the current instant.
+   */
+  getNextEclipses(timezone?: string): ServiceResult<Record<string, unknown>> {
+    const resolvedTimezone = resolveReportingTimezone(this.mcpStartupDefaults, timezone);
+    const jd = this.ephem.dateToJulianDay(this.now());
+
+    const solarEclipse = this.eclipseCalc.findNextSolarEclipse(jd);
+    const lunarEclipse = this.eclipseCalc.findNextLunarEclipse(jd);
+
+    const eclipses: Array<{ type: string; eclipseType: string; maxTime: string }> = [];
+    const humanLines: string[] = [];
+
+    if (solarEclipse) {
+      eclipses.push({
+        type: solarEclipse.type,
+        eclipseType: solarEclipse.eclipseType,
+        maxTime: solarEclipse.maxTime.toISOString(),
+      });
+      humanLines.push(
+        `Next Solar Eclipse: ${this.formatTimestamp(solarEclipse.maxTime, resolvedTimezone)} (${solarEclipse.eclipseType})`
+      );
+    }
+
+    if (lunarEclipse) {
+      eclipses.push({
+        type: lunarEclipse.type,
+        eclipseType: lunarEclipse.eclipseType,
+        maxTime: lunarEclipse.maxTime.toISOString(),
+      });
+      humanLines.push(
+        `Next Lunar Eclipse: ${this.formatTimestamp(lunarEclipse.maxTime, resolvedTimezone)} (${lunarEclipse.eclipseType})`
+      );
+    }
+
+    const structuredData = { timezone: resolvedTimezone, eclipses };
+    const humanText =
+      eclipses.length === 0
+        ? 'No eclipses found in the near future.'
+        : `Upcoming Eclipses:\n\n${humanLines.join('\n')}`;
+
+    return { data: structuredData, text: humanText };
+  }
+
+  private getDateLabel(date: Date, timezone: string): string {
+    const localDate = utcToLocal(date, timezone);
+    return `${localDate.year}-${String(localDate.month).padStart(2, '0')}-${String(localDate.day).padStart(2, '0')}`;
+  }
+}

--- a/tests/unit/astro-service-chart-output-service.test.ts
+++ b/tests/unit/astro-service-chart-output-service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ChartOutputService } from '../../src/astro-service/chart-output-service.js';
+import type { NatalChart, PlanetPosition } from '../../src/types.js';
+
+function makePlanet(planet: PlanetPosition['planet'], longitude: number): PlanetPosition {
+  return {
+    planetId: 0,
+    planet,
+    longitude,
+    latitude: 0,
+    distance: 1,
+    speed: 1,
+    sign: 'Aries',
+    degree: longitude % 30,
+    isRetrograde: false,
+  };
+}
+
+function makeNatalChart(): NatalChart {
+  return {
+    name: 'Test User',
+    birthDate: { year: 1990, month: 6, day: 12, hour: 14, minute: 35 },
+    location: { latitude: 37.7749, longitude: -122.4194, timezone: 'America/Los_Angeles' },
+    planets: [makePlanet('Sun', 10), makePlanet('Moon', 20)],
+    julianDay: 2451545,
+    houseSystem: 'P',
+    utcDateTime: { year: 1990, month: 6, day: 12, hour: 21, minute: 35 },
+  };
+}
+
+function makeChartOutputService() {
+  const chartRenderer = {
+    generateNatalChart: vi.fn(async (_chart, _theme, format) => {
+      if (format === 'svg') return '<svg>ok</svg>';
+      return Buffer.from([1, 2, 3]);
+    }),
+    generateTransitChart: vi.fn(async (_chart, _date, _theme, format) => {
+      if (format === 'svg') return '<svg>transit</svg>';
+      return Buffer.from([4, 5, 6]);
+    }),
+  };
+  const now = vi.fn(() => new Date('2024-03-26T12:00:00Z'));
+  const writeFile = vi.fn(async () => {});
+
+  const chartOutputService = new ChartOutputService({
+    chartRenderer: chartRenderer as any,
+    now,
+    writeFile,
+  });
+
+  return { chartOutputService, chartRenderer, now, writeFile };
+}
+
+describe('When using the extracted ChartOutputService', () => {
+  it('Given inline render requests, then it preserves SVG and binary output serialization', async () => {
+    const { chartOutputService } = makeChartOutputService();
+
+    const inlineSvg = await chartOutputService.generateNatalChart(makeNatalChart(), { format: 'svg' });
+    expect(inlineSvg).toMatchObject({
+      format: 'svg',
+      text: 'Natal Chart for Test User:',
+      svg: '<svg>ok</svg>',
+    });
+
+    const inlinePng = await chartOutputService.generateNatalChart(makeNatalChart(), { format: 'png' });
+    expect(inlinePng).toMatchObject({
+      format: 'png',
+      image: {
+        data: Buffer.from([1, 2, 3]).toString('base64'),
+        mimeType: 'image/png',
+      },
+    });
+  });
+
+  it('Given transit chart output paths and dates, then it preserves saved-file and label behavior', async () => {
+    const { chartOutputService, writeFile } = makeChartOutputService();
+
+    const saved = await chartOutputService.generateTransitChart(makeNatalChart(), {
+      format: 'webp',
+      output_path: '/tmp/test.webp',
+      date: '2024-03-26',
+    });
+
+    expect(writeFile).toHaveBeenCalledWith('/tmp/test.webp', Buffer.from([4, 5, 6]));
+    expect(saved.text).toContain('Transit Chart for Test User');
+    expect(saved.text).toContain('/tmp/test.webp');
+  });
+});

--- a/tests/unit/astro-service-natal-service.test.ts
+++ b/tests/unit/astro-service-natal-service.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NatalService } from '../../src/astro-service/natal-service.js';
+import type { McpStartupDefaults } from '../../src/entrypoint.js';
+import type { NatalChart, PlanetPosition } from '../../src/types.js';
+
+function makePlanet(planet: PlanetPosition['planet'], longitude: number): PlanetPosition {
+  return {
+    planetId: 0,
+    planet,
+    longitude,
+    latitude: 0,
+    distance: 1,
+    speed: 1,
+    sign: 'Aries',
+    degree: longitude % 30,
+    isRetrograde: false,
+  };
+}
+
+function makeNatalChart(): NatalChart {
+  return {
+    name: 'Test User',
+    birthDate: { year: 1990, month: 6, day: 12, hour: 14, minute: 35 },
+    location: { latitude: 37.7749, longitude: -122.4194, timezone: 'America/Los_Angeles' },
+    planets: [makePlanet('Sun', 10), makePlanet('Moon', 20)],
+    julianDay: 2451545,
+    houseSystem: 'P',
+    utcDateTime: { year: 1990, month: 6, day: 12, hour: 21, minute: 35 },
+  };
+}
+
+function makeNatalService(mcpStartupDefaults: McpStartupDefaults = {}) {
+  const ephem = {
+    dateToJulianDay: vi.fn((date: Date) => date.getTime() / 86400000 + 2440587.5),
+    getAllPlanets: vi.fn(() => [makePlanet('Sun', 204), makePlanet('Moon', 270)]),
+  };
+  const houseCalc = {
+    calculateHouses: vi.fn(() => ({
+      ascendant: 270,
+      mc: 204,
+      cusps: [0, 270, 300, 330, 0, 30, 60, 90, 120, 150, 204, 240, 260],
+      system: 'W' as const,
+    })),
+  };
+  const isInitialized = vi.fn(() => true);
+
+  const natalService = new NatalService({
+    ephem: ephem as any,
+    houseCalc: houseCalc as any,
+    mcpStartupDefaults,
+    isInitialized,
+  });
+
+  return { natalService, ephem, houseCalc, isInitialized };
+}
+
+describe('When using the extracted NatalService', () => {
+  it('Given a polar latitude chart, then it preserves natal fallback house behavior', () => {
+    const { natalService } = makeNatalService();
+
+    const result = natalService.setNatalChart({
+      name: 'Polar User',
+      year: 1990,
+      month: 6,
+      day: 12,
+      hour: 14,
+      minute: 35,
+      latitude: 78,
+      longitude: 15,
+      timezone: 'UTC',
+      house_system: 'P',
+    });
+
+    expect(result.chart.houseSystem).toBe('W');
+    expect(result.data).toMatchObject({
+      name: 'Polar User',
+      requestedHouseSystem: 'P',
+      resolvedHouseSystem: 'W',
+      isPolar: true,
+    });
+  });
+
+  it('Given state and defaults, then it preserves server status and house validation behavior', () => {
+    const { natalService, isInitialized } = makeNatalService({
+      preferredTimezone: 'UTC',
+      preferredHouseStyle: 'W',
+      weekdayLabels: true,
+    });
+
+    const status = natalService.getServerStatus(makeNatalChart());
+    expect(isInitialized).toHaveBeenCalled();
+    expect(status.data).toMatchObject({
+      hasNatalChart: true,
+      natalChartName: 'Test User',
+      startupDefaults: {
+        preferredTimezone: 'UTC',
+        preferredHouseStyle: 'W',
+        weekdayLabels: true,
+      },
+      ephemerisInitialized: true,
+    });
+
+    expect(() => natalService.getHouses({ ...makeNatalChart(), julianDay: undefined })).toThrow(
+      /missing julianDay/i
+    );
+  });
+});

--- a/tests/unit/astro-service-sky-service.test.ts
+++ b/tests/unit/astro-service-sky-service.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SkyService } from '../../src/astro-service/sky-service.js';
+import type { McpStartupDefaults } from '../../src/entrypoint.js';
+import type { NatalChart, PlanetPosition, RiseSetTime } from '../../src/types.js';
+
+function makePlanet(planet: PlanetPosition['planet'], longitude: number): PlanetPosition {
+  return {
+    planetId: 0,
+    planet,
+    longitude,
+    latitude: 0,
+    distance: 1,
+    speed: 1,
+    sign: 'Aries',
+    degree: longitude % 30,
+    isRetrograde: false,
+  };
+}
+
+function makeNatalChart(): NatalChart {
+  return {
+    name: 'Test User',
+    birthDate: { year: 1990, month: 6, day: 12, hour: 14, minute: 35 },
+    location: { latitude: 37.7749, longitude: -122.4194, timezone: 'America/Los_Angeles' },
+    planets: [makePlanet('Sun', 10), makePlanet('Moon', 20)],
+    julianDay: 2451545,
+    houseSystem: 'P',
+    utcDateTime: { year: 1990, month: 6, day: 12, hour: 21, minute: 35 },
+  };
+}
+
+function makeSkyService(mcpStartupDefaults: McpStartupDefaults = {}) {
+  const ephem = {
+    dateToJulianDay: vi.fn((date: Date) => date.getTime() / 86400000 + 2440587.5),
+    getAllPlanets: vi.fn(() => [makePlanet('Mercury', 42), { ...makePlanet('Saturn', 315), sign: 'Aquarius', isRetrograde: true }]),
+  };
+  const riseSetCalc = {
+    getAllRiseSet: vi.fn(async () => [
+      {
+        planet: 'Sun',
+        rise: new Date('2024-03-26T13:00:00Z'),
+        set: new Date('2024-03-27T01:00:00Z'),
+      },
+    ] as RiseSetTime[]),
+  };
+  const eclipseCalc = {
+    findNextSolarEclipse: vi.fn(() => ({
+      type: 'solar' as const,
+      date: new Date('2024-04-08T18:00:00Z'),
+      eclipseType: 'Total',
+      maxTime: new Date('2024-04-08T18:00:00Z'),
+    })),
+    findNextLunarEclipse: vi.fn(() => null),
+  };
+  const now = vi.fn(() => new Date('2024-03-26T12:00:00Z'));
+  const formatTimestamp = vi.fn((date: Date, timezone: string) => `${timezone}:${date.toISOString()}`);
+
+  const skyService = new SkyService({
+    ephem: ephem as any,
+    riseSetCalc: riseSetCalc as any,
+    eclipseCalc: eclipseCalc as any,
+    mcpStartupDefaults,
+    now,
+    formatTimestamp,
+  });
+
+  return { skyService, ephem, riseSetCalc, eclipseCalc, now, formatTimestamp };
+}
+
+describe('When using the extracted SkyService', () => {
+  it('Given current planetary motion, then it preserves retrograde and asteroid payloads', () => {
+    const { skyService, ephem } = makeSkyService({ preferredTimezone: 'UTC' });
+
+    const retro = skyService.getRetrogradePlanets();
+    expect(retro.data).toMatchObject({
+      date: '2024-03-26',
+      timezone: 'UTC',
+    });
+    expect((retro.data as any).planets).toEqual(
+      expect.arrayContaining([expect.objectContaining({ planet: 'Saturn', isRetrograde: true })])
+    );
+
+    ephem.getAllPlanets.mockReturnValueOnce([
+      { ...makePlanet('True Node', 120), sign: 'Leo' },
+      { ...makePlanet('Chiron', 210), sign: 'Scorpio', isRetrograde: true },
+    ]);
+    const asteroidPositions = skyService.getAsteroidPositions('UTC');
+    expect(asteroidPositions.text).toContain('Rx');
+  });
+
+  it('Given runtime rise-set and eclipse lookups, then it preserves readable summaries', async () => {
+    const { skyService } = makeSkyService({ preferredTimezone: 'UTC' });
+
+    const riseSet = await skyService.getRiseSetTimes(makeNatalChart());
+    expect(riseSet.data).toMatchObject({
+      date: '2024-03-26',
+      timezone: 'America/Los_Angeles',
+    });
+    expect(riseSet.text).toContain('Rise/Set Times');
+
+    const eclipses = skyService.getNextEclipses('UTC');
+    expect(eclipses.data).toMatchObject({
+      timezone: 'UTC',
+      eclipses: [expect.objectContaining({ type: 'solar', eclipseType: 'Total' })],
+    });
+    expect(eclipses.text).toContain('Next Solar Eclipse');
+  });
+});


### PR DESCRIPTION
## Summary
- extract natal/chart-state workflows into an internal `NatalService`
- extract current-sky/runtime lookups into an internal `SkyService`
- extract chart rendering/output behavior into an internal `ChartOutputService`
- keep `AstroService` as the stable facade and add seam-level tests for the new services

## Verification
- `npm run build`
- `npm run lint`
- `npm run quality:gate`