### PR TITLE
chore(release): 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ether-to-astro",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ether-to-astro",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ether-to-astro",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Local-first astrology toolkit with a unified e2a binary for CLI and MCP workflows, plus an e2a-mcp compatibility alias.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What changed
This PR contains the patch release bump for `1.3.1` after the merged hotfix for npm/npx bin entrypoints.

## Included in 1.3.1
- restore `e2a` and `e2a-mcp` when launched through npm/npx-generated bin shims
- keep regression coverage for symlinked bin invocation without depending on executable file mode in CI

## Validation
- `npm run build`
- `npm run lint`
- `npm test -- --run`

## Release note
`main` is branch-protected, so the version-bump commit must merge through PR before the `v1.3.1` tag and GitHub Release are published from `main`.